### PR TITLE
Register testnet server as vite plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "testnet": "npx vite-node ./src/testnet.ts",
     "dev:testnet": "VITE_USE_TESTNET=true yarn dev",
     "build": "tsc && vite build",
     "preview": "vite-node ./preview-server.ts",
+    "preview:testnet": "VITE_USE_TESTNET=true yarn preview",
     "typecheck": "tsc --noEmit",
     "lint": "npm run lint:js && npm run lint:css",
     "lint:js": "eslint ./src",

--- a/src/engine/MainThread.ts
+++ b/src/engine/MainThread.ts
@@ -288,7 +288,7 @@ export async function initEngine(canvas: HTMLCanvasElement): Promise<Engine> {
 
   return {
     startTestNet() {
-      ws = new WebSocket("ws://localhost:8080");
+      ws = new WebSocket("ws://localhost:9090");
       ws.binaryType = "arraybuffer";
 
       ws.addEventListener("open", (data) => {

--- a/src/testnet.ts
+++ b/src/testnet.ts
@@ -1,4 +1,5 @@
-import WebSocket, { WebSocketServer } from "ws";
+import { WebSocket, WebSocketServer } from "ws";
+import { Plugin } from "vite";
 
 function generateUUID() {
   let d = new Date().getTime();
@@ -16,74 +17,87 @@ function generateUUID() {
   });
 }
 
-const host = "localhost";
-const port = 8080;
-const wss = new WebSocketServer({ host, port });
+function initTestnetServer() {
+  const host = "localhost";
+  const port = 9090;
+  const wss = new WebSocketServer({ host, port });
 
-let connections = 0;
-let peerHost: WebSocket | undefined;
-const peers: { [key: string]: WebSocket } = {};
-const peerIds = new Map();
-const informedPeerIds = new Map();
+  let connections = 0;
+  let peerHost: WebSocket | undefined;
+  const peers: { [key: string]: WebSocket } = {};
+  const peerIds = new Map();
+  const informedPeerIds = new Map();
 
-wss.on("connection", (ws) => {
-  connections++;
+  wss.on("connection", (ws) => {
+    connections++;
 
-  ws.binaryType = "arraybuffer";
+    ws.binaryType = "arraybuffer";
 
-  const peerId = generateUUID();
-  peers[peerId] = ws;
-  peerIds.set(ws, peerId);
-  informedPeerIds.set(peerId, new Set());
+    const peerId = generateUUID();
+    peers[peerId] = ws;
+    peerIds.set(ws, peerId);
+    informedPeerIds.set(peerId, new Set());
 
-  console.log("new client", peerId);
+    console.log("new client", peerId);
 
-  if (connections === 1) {
-    ws.send("setHost");
-    console.log("setHost", peerId);
-    peerHost = ws;
-  }
-
-  ws.send(JSON.stringify({ setPeerId: peerId }));
-
-  if (connections > 1) {
-    // inform existing peers of new peerId
-    const informed = informedPeerIds.get(peerId);
-    for (const peerIdA in peers) {
-      const alreadyInformed = informedPeerIds.get(peerId)?.has(peerIdA);
-      if (alreadyInformed) continue;
-
-      // no need to send peerId to itself
-      if (peerId === peerIdA) continue;
-
-      ws.send(JSON.stringify({ addPeerId: peerIdA }));
-      peers[peerIdA].send(JSON.stringify({ addPeerId: peerId }));
-      informed.add(peerIdA);
-
-      console.log("informed", peerId, "and", peerIdA, "of one another");
+    if (connections === 1) {
+      ws.send("setHost");
+      console.log("setHost", peerId);
+      peerHost = ws;
     }
-  }
 
-  ws.on("close", () => {
-    console.log("closed connection", peerId);
-    connections--;
-    if (connections === 0) peerHost = undefined;
-    delete peers[peerId];
-    informedPeerIds.delete(peerId);
-    if (ws === peerHost) {
-      console.log("host changed to", peerId);
-      peerHost = peers[Object.keys(peers)[0]];
+    ws.send(JSON.stringify({ setPeerId: peerId }));
+
+    if (connections > 1) {
+      // inform existing peers of new peerId
+      const informed = informedPeerIds.get(peerId);
+      for (const peerIdA in peers) {
+        const alreadyInformed = informedPeerIds.get(peerId)?.has(peerIdA);
+        if (alreadyInformed) continue;
+
+        // no need to send peerId to itself
+        if (peerId === peerIdA) continue;
+
+        ws.send(JSON.stringify({ addPeerId: peerIdA }));
+        peers[peerIdA].send(JSON.stringify({ addPeerId: peerId }));
+        informed.add(peerIdA);
+
+        console.log("informed", peerId, "and", peerIdA, "of one another");
+      }
     }
-  });
 
-  ws.on("message", (data, isBinary) => {
-    // console.log("new msg", data, isBinary);
-    wss.clients.forEach((client) => {
-      if (client !== ws && client.readyState === WebSocket.OPEN) {
-        client.send(data, { binary: isBinary });
+    ws.on("close", () => {
+      console.log("closed connection", peerId);
+      connections--;
+      if (connections === 0) peerHost = undefined;
+      delete peers[peerId];
+      informedPeerIds.delete(peerId);
+      if (ws === peerHost) {
+        console.log("host changed to", peerId);
+        peerHost = peers[Object.keys(peers)[0]];
       }
     });
-  });
-});
 
-console.log(`websocket server started at ws://${host}:${port}`);
+    ws.on("message", (data, isBinary) => {
+      // console.log("new msg", data, isBinary);
+      wss.clients.forEach((client) => {
+        if (client !== ws && client.readyState === WebSocket.OPEN) {
+          client.send(data, { binary: isBinary });
+        }
+      });
+    });
+  });
+
+  console.log(`Testnet websocket server started at ws://${host}:${port}`);
+}
+
+export default function TestnetServerPlugin(): Plugin {
+  return {
+    name: "testnet-server",
+    configureServer() {
+      if (process.env.VITE_USE_TESTNET) {
+        initTestnetServer();
+      }
+    },
+  };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,9 +4,11 @@ import postcssPresetEnv from "postcss-preset-env";
 import crossOriginIsolation from "vite-plugin-cross-origin-isolation";
 import pluginRewriteAll from "vite-plugin-rewrite-all";
 
+import testnetServerPlugin from "./src/testnet";
+
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [pluginRewriteAll(), react(), crossOriginIsolation()],
+  plugins: [pluginRewriteAll(), react(), crossOriginIsolation(), testnetServerPlugin()],
   resolve: {
     dedupe: ["three", "bitecs"],
   },


### PR DESCRIPTION
Removes the need to run `yarn testnet` before running `yarn dev:testnet`. I also added the `yarn preview:testnet` command so you can test using the testnet in Firefox and Safari.