### PR TITLE
Update three.js to v140

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "6",
-    "three": "mrdoob/three.js#4f94d21351c74b90720a6e1540b2b7e528a26a33",
+    "three": "0.140.0",
     "zustand": "^4.0.0-rc.0"
   },
   "devDependencies": {
@@ -48,7 +48,7 @@
     "@types/postcss-preset-env": "^6.7.3",
     "@types/react": "^17.0.33",
     "@types/react-dom": "^17.0.10",
-    "@types/three": "^0.138.0",
+    "@types/three": "0.139.0",
     "@types/ws": "^8.5.3",
     "@typescript-eslint/eslint-plugin": "^5.17.0",
     "@typescript-eslint/parser": "^5.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -894,10 +894,10 @@
   dependencies:
     "@types/jest" "*"
 
-"@types/three@^0.138.0":
-  version "0.138.0"
-  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.138.0.tgz#ec9f1d1fd8dffea2e0572f9d815ff5a35cf4dc6b"
-  integrity sha512-D8AoV7h2kbCfrv/DcebHOFh1WDwyus3HdooBkAwcBikXArdqnsQ38PQ85JCunnvun160oA9jz53GszF3zch3tg==
+"@types/three@0.139.0":
+  version "0.139.0"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.139.0.tgz#69af1f0c52f8eea390f513e05478af1dd7f49e6f"
+  integrity sha512-4V/jZhyq7Mv05coUzxL3bz8AuBOSi/1F0RY7ujisHTV0Amy/fnYJ+s7TSJ1/hXjZukSkpuFRgV+wvWUEMbsMbQ==
 
 "@types/ws@^8.5.3":
   version "8.5.3"
@@ -4344,9 +4344,10 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-three@mrdoob/three.js#4f94d21351c74b90720a6e1540b2b7e528a26a33:
-  version "0.139.1"
-  resolved "https://codeload.github.com/mrdoob/three.js/tar.gz/4f94d21351c74b90720a6e1540b2b7e528a26a33"
+three@0.140.0:
+  version "0.140.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.140.0.tgz#5ad85df954c63015337a846134e0daa6c7c0dead"
+  integrity sha512-jcHjbnYspPLDdsDQChmzyAoZ5KhJbgFk6pNGlAIc9fQMvsfPGjF5H9glrngqvb2CR/qXcClMyp5PYdF996lldA==
 
 tinypool@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
Still waiting on updated typescript definitions. Upgraded `@types/three` from `0.138.0` to `0.139.0` and typechecking passes.

Will update types to `0.140` when https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60143 is released.