### PR TITLE
More refactoring of global state

### DIFF
--- a/src/hydrogen-view-sdk.d.ts
+++ b/src/hydrogen-view-sdk.d.ts
@@ -337,7 +337,19 @@ declare module "@thirdroom/hydrogen-view-sdk" {
     Public,
   }
 
-  type RoomBeingCreated = any;
+  export class RoomBeingCreated extends EventEmitter<any> {
+    public readonly id: string;
+    public readonly mediaRepository: MediaRepository;
+    public readonly platform: Platform;
+    get avatarColorId(): string;
+    get avatarUrl(): string | undefined;
+    get avatarBlobUrl(): string | undefined;
+    get roomId(): string | undefined;
+    get name(): string;
+    get isBeingCreated(): boolean;
+    get error(): Error | undefined;
+    cancel(): void;
+  }
 
   export enum RoomStatus {
     None = 1 << 0,
@@ -352,6 +364,7 @@ declare module "@thirdroom/hydrogen-view-sdk" {
     userId: string;
     mediaRepository: MediaRepository;
     rooms: ObservableMap<string, Room>;
+    roomsBeingCreated: ObservableMap<string, RoomBeingCreated>;
     callHandler: CallHandler;
     createRoom(options: any): RoomBeingCreated;
     joinRoom(roomIdOrAlias: string, log?: ILogger): Promise<string>;

--- a/src/ui/hooks/useRoomBeingCreated.ts
+++ b/src/ui/hooks/useRoomBeingCreated.ts
@@ -1,0 +1,8 @@
+import { RoomBeingCreated, Session } from "@thirdroom/hydrogen-view-sdk";
+
+import { useObservableMap } from "./useObservableMap";
+
+export function useRoomBeingCreated(session: Session, roomId: string | undefined): RoomBeingCreated | undefined {
+  const roomsBeingCreated = useObservableMap(() => session.roomsBeingCreated, [session.roomsBeingCreated]);
+  return roomId ? roomsBeingCreated.get(roomId) : undefined;
+}

--- a/src/ui/hooks/useStore.ts
+++ b/src/ui/hooks/useStore.ts
@@ -1,132 +1,214 @@
 import create from "zustand";
-import produce from "immer";
+import { immer } from "zustand/middleware/immer";
 import { RoomId } from "@thirdroom/hydrogen-view-sdk";
 
 import { RoomListTabs } from "../views/session/sidebar/RoomListHeader";
 
+export enum WorldLoadState {
+  None = "none",
+  Loading = "loading",
+  Loaded = "loaded",
+  Entering = "entering",
+  Entered = "entered",
+  Error = "error",
+}
+
 export interface OverlayState {
   isOpen: boolean;
+  openOverlay(): void;
+  closeOverlay(): void;
+}
+
+export interface OverlaySidebarState {
   selectedRoomListTab: RoomListTabs;
-  activeChats: Set<RoomId>;
-  selectedChatId: RoomId | undefined;
+  selectRoomListTab(tab: RoomListTabs): void;
+}
+
+export interface OverlayWorldState {
   selectedWorldId: RoomId | undefined;
+  selectWorld(roomId: RoomId | undefined): void;
+}
+
+export interface OverlayChatState {
+  selectedChatId: RoomId | undefined;
+  activeChats: Set<RoomId>;
+  selectChat(roomId: RoomId | undefined): void;
+  minimizeChat(roomId: RoomId): void;
+  closeChat(roomId: RoomId): void;
 }
 
 export interface WorldState {
-  isChatOpen: boolean;
-  isPointerLock: boolean;
-  loadedWorldId: RoomId | undefined;
   isEnteredWorld: boolean;
+  worldId: RoomId | undefined;
+  loadState: WorldLoadState;
+  loadError?: Error;
+  setInitialWorld(roomId: RoomId | undefined): void;
+  loadingWorld(roomId: RoomId | undefined): void;
+  loadedWorld(): void;
+  loadWorldError(error: Error): void;
+  enteringWorld(): void;
+  enteredWorld(): void;
+  leftWorld(): void;
+}
+
+export interface WorldChatState {
+  isOpen: boolean;
+  openWorldChat(): void;
+  closeWorldChat(): void;
+}
+
+export interface PointerLockState {
+  isPointerLock: boolean;
+  setIsPointerLock(isPointerLock: boolean): void;
 }
 
 export interface StoreState {
   overlay: OverlayState;
+  overlaySidebar: OverlaySidebarState;
+  overlayChat: OverlayChatState;
+  overlayWorld: OverlayWorldState;
   world: WorldState;
+  worldChat: WorldChatState;
+  pointerLock: PointerLockState;
 }
 
-export const useStore = create<StoreState>(() => ({
-  overlay: {
-    isOpen: true,
-    selectedRoomListTab: RoomListTabs.Home,
-    activeChats: new Set(),
-    selectedChatId: undefined,
-    selectedWorldId: undefined,
-  },
-  world: {
-    isChatOpen: false,
-    isPointerLock: false,
-    loadedWorldId: undefined,
-    isEnteredWorld: false,
-  },
-}));
+export const useStore = create<StoreState>()(
+  immer((set, get) => ({
+    overlay: {
+      isOpen: true,
+      openOverlay() {
+        set((state) => {
+          state.overlay.isOpen = true;
+        });
+      },
+      closeOverlay() {
+        set((state) => {
+          state.overlay.isOpen = false;
+        });
+      },
+    },
+    overlaySidebar: {
+      selectedRoomListTab: RoomListTabs.Home,
+      selectRoomListTab(tab: RoomListTabs) {
+        set((state) => {
+          state.overlaySidebar.selectedRoomListTab = tab;
+        });
+      },
+    },
+    overlayChat: {
+      activeChats: new Set(),
+      selectedChatId: undefined,
+      selectChat(roomId: RoomId) {
+        set((state) => {
+          if (!state.overlayChat.activeChats.has(roomId)) {
+            state.overlayChat.activeChats.add(roomId);
+          }
 
-export function openOverlay() {
-  useStore.setState(
-    produce((state) => {
-      state.overlay.isOpen = true;
-    })
-  );
-}
-export function closeOverlay() {
-  useStore.setState(
-    produce((state) => {
-      state.overlay.isOpen = false;
-    })
-  );
-}
+          if (state.overlayChat.selectedChatId === roomId) {
+            state.overlayChat.selectedChatId = undefined;
+          } else {
+            state.overlayChat.selectedChatId = roomId;
+          }
+        });
+      },
+      minimizeChat(roomId: RoomId) {
+        set((state) => {
+          state.overlayChat.selectedChatId = undefined;
+        });
+      },
+      closeChat(roomId: RoomId) {
+        set((state) => {
+          if (state.overlayChat.selectedChatId === roomId) {
+            state.overlayChat.selectedChatId = undefined;
+          }
 
-export function selectRoomListTab(tab: RoomListTabs) {
-  useStore.setState(
-    produce((state) => {
-      state.overlay.selectedRoomListTab = tab;
-    })
-  );
-}
-
-export function addActiveChat(roomId: RoomId) {
-  useStore.setState(
-    produce((state) => {
-      state.overlay.activeChats.add(roomId);
-    })
-  );
-}
-export function deleteActiveChat(roomId: RoomId) {
-  useStore.setState(
-    produce((state) => {
-      state.overlay.activeChats.delete(roomId);
-    })
-  );
-}
-
-export function selectChat(roomId: RoomId | undefined) {
-  useStore.setState(
-    produce((state) => {
-      state.overlay.selectedChatId = roomId;
-    })
-  );
-}
-
-export function selectWorld(roomId: RoomId | undefined) {
-  useStore.setState(
-    produce((state) => {
-      state.overlay.selectedWorldId = roomId;
-    })
-  );
-}
-export function loadWorld(roomId: RoomId | undefined) {
-  useStore.setState(
-    produce((state) => {
-      state.world.loadedWorldId = roomId;
-    })
-  );
-}
-export function setIsEnteredWorld(isEntered: boolean) {
-  useStore.setState(
-    produce((state) => {
-      state.world.isEnteredWorld = isEntered;
-    })
-  );
-}
-
-export function setIsPointerLock(isPointerLock: boolean) {
-  useStore.setState(
-    produce((state) => {
-      state.world.isPointerLock = isPointerLock;
-    })
-  );
-}
-
-export function openWorldChat() {
-  useStore.setState(
-    produce((state) => {
-      state.world.isChatOpen = true;
-    })
-  );
-}
-export function closeWorldChat() {
-  useStore.setState(
-    produce((state) => {
-      state.world.isChatOpen = false;
-    })
-  );
-}
+          state.overlayChat.activeChats.delete(roomId);
+        });
+      },
+    },
+    overlayWorld: {
+      selectedWorldId: undefined,
+      selectWorld(roomId: RoomId | undefined) {
+        set((state) => {
+          state.overlayChat.selectedChatId = undefined;
+          state.overlayWorld.selectedWorldId = roomId;
+        });
+      },
+    },
+    world: {
+      isEnteredWorld: false,
+      worldId: undefined,
+      loadState: WorldLoadState.None,
+      loadError: undefined,
+      setInitialWorld(roomId: RoomId | undefined) {
+        set((state) => {
+          state.overlayWorld.selectedWorldId = roomId;
+          state.world.worldId = roomId;
+          state.world.loadError = undefined;
+          state.world.loadState = WorldLoadState.None;
+        });
+      },
+      loadingWorld(roomId: RoomId | undefined) {
+        set((state) => {
+          state.overlayWorld.selectedWorldId = roomId;
+          state.world.worldId = roomId;
+          state.world.loadError = undefined;
+          state.world.loadState = roomId ? WorldLoadState.Loading : WorldLoadState.None;
+        });
+      },
+      loadedWorld() {
+        set((state) => {
+          state.world.loadState = WorldLoadState.Loaded;
+        });
+      },
+      loadWorldError(error: Error) {
+        set((state) => {
+          state.world.loadState = WorldLoadState.Error;
+          state.world.loadError = error as Error;
+        });
+      },
+      enteringWorld() {
+        set((state) => {
+          state.world.loadState = WorldLoadState.Entering;
+        });
+      },
+      enteredWorld() {
+        set((state) => {
+          state.world.isEnteredWorld = true;
+          state.world.loadState = WorldLoadState.Entered;
+          state.overlay.isOpen = false;
+        });
+      },
+      leftWorld() {
+        set((state) => {
+          state.world.isEnteredWorld = false;
+          state.world.worldId = undefined;
+          state.world.loadState = WorldLoadState.None;
+          state.worldChat.isOpen = false;
+          state.overlay.isOpen = true;
+        });
+      },
+    },
+    worldChat: {
+      isOpen: false,
+      openWorldChat() {
+        set((state) => {
+          state.worldChat.isOpen = true;
+        });
+      },
+      closeWorldChat() {
+        set((state) => {
+          state.worldChat.isOpen = false;
+        });
+      },
+    },
+    pointerLock: {
+      isPointerLock: false,
+      setIsPointerLock(isPointerLock: boolean) {
+        set((state) => {
+          state.pointerLock.isPointerLock = isPointerLock;
+        });
+      },
+    },
+  }))
+);

--- a/src/ui/views/session/SessionView.tsx
+++ b/src/ui/views/session/SessionView.tsx
@@ -9,22 +9,14 @@ import { StatusBar } from "./statusbar/StatusBar";
 import { useRoom } from "../../hooks/useRoom";
 import { useHydrogen } from "../../hooks/useHydrogen";
 import { useCalls } from "../../hooks/useCalls";
-import {
-  useStore,
-  closeOverlay,
-  loadWorld,
-  setIsEnteredWorld,
-  openOverlay,
-  closeWorldChat,
-} from "../../hooks/useStore";
+import { useStore } from "../../hooks/useStore";
 import { createMatrixNetworkInterface } from "../../../engine/network/createMatrixNetworkInterface";
 import { useAsyncObservableValue } from "../../hooks/useAsyncObservableValue";
 
 export interface SessionOutletContext {
-  loadedWorld?: Room;
+  world?: Room;
   activeCall?: GroupCall;
   canvasRef: RefObject<HTMLCanvasElement>;
-  onEnteredWorld: () => void;
   onLeftWorld: () => void;
 }
 
@@ -41,30 +33,28 @@ export function SessionView() {
   const homeMatch = useMatch({ path: "/", end: true });
   const isHome = homeMatch !== null;
 
-  const worldMatch = useMatch({ path: "world/:worldId" });
-  const loadedWorldId = useStore((state) => state.world.loadedWorldId);
-  const loadedWorld = useRoom(session, loadedWorldId);
+  const worldMatch = useMatch({ path: "world/:worldId/*" });
+  const { worldId, setInitialWorld, leftWorld, enteredWorld } = useStore((state) => state.world);
+  const world = useRoom(session, worldId);
+
+  const nextWorldId = worldMatch ? worldMatch.params["worldId"] || location.hash : undefined;
 
   useEffect(() => {
-    const newLoadedWId = worldMatch ? worldMatch.params["worldId"] || location.hash : undefined;
-    loadWorld(newLoadedWId);
-  }, [worldMatch, location]);
+    setInitialWorld(nextWorldId);
+  }, [nextWorldId, setInitialWorld]);
 
   const { value: powerLevels } = useAsyncObservableValue(
-    () => (loadedWorld ? loadedWorld.observePowerLevels() : Promise.resolve(new ObservableValue(undefined))),
-    [loadedWorld]
+    () => (world ? world.observePowerLevels() : Promise.resolve(new ObservableValue(undefined))),
+    [world]
   );
   const calls = useCalls(session);
   const activeCall = useMemo(() => {
-    const roomCalls = Array.from(calls).flatMap(([_callId, call]) => (call.roomId === loadedWorldId ? call : []));
+    const roomCalls = Array.from(calls).flatMap(([_callId, call]) => (call.roomId === worldId ? call : []));
     return roomCalls.length ? roomCalls[0] : undefined;
-  }, [calls, loadedWorldId]);
+  }, [calls, worldId]);
 
   const onLeftWorld = useCallback(() => {
-    loadWorld(undefined);
-    setIsEnteredWorld(false);
-    closeWorldChat();
-    openOverlay();
+    leftWorld();
     document.exitPointerLock();
 
     if (activeCall) {
@@ -74,25 +64,29 @@ export function SessionView() {
     if (networkInterfaceRef.current) {
       networkInterfaceRef.current();
     }
-  }, [activeCall]);
-  const onEnteredWorld = useCallback(() => {
-    closeOverlay();
-    setIsEnteredWorld(true);
-    canvasRef.current?.requestPointerLock();
+  }, [activeCall, leftWorld]);
 
-    if (import.meta.env.VITE_USE_TESTNET) {
-      engine?.startTestNet();
-      return;
-    }
+  const onEnteredWorld = useCallback(
+    (call: GroupCall) => {
+      enteredWorld();
+      canvasRef.current?.requestPointerLock();
 
-    if (engine && activeCall && powerLevels) {
-      networkInterfaceRef.current = createMatrixNetworkInterface(engine, client, powerLevels, activeCall);
-    }
-  }, [client, engine, activeCall, powerLevels]);
+      if (import.meta.env.VITE_USE_TESTNET) {
+        engine?.startTestNet();
+        return;
+      }
+
+      if (engine && powerLevels) {
+        networkInterfaceRef.current = createMatrixNetworkInterface(engine, client, powerLevels, call);
+      }
+    },
+    [client, engine, powerLevels, enteredWorld]
+  );
 
   const onLoadWorld = useCallback(
     async (room: Room) => {
       const isEnteredWorld = useStore.getState().world.isEnteredWorld;
+
       if (isEnteredWorld) {
         onLeftWorld();
       }
@@ -117,31 +111,31 @@ export function SessionView() {
       const localMedia = new LocalMedia().withUserMedia(stream).withDataChannel({});
       await call.join(localMedia);
 
-      onEnteredWorld();
+      onEnteredWorld(call);
     },
     [platform, session, calls, onEnteredWorld]
   );
 
   const outletContext = useMemo<SessionOutletContext>(
     () => ({
-      loadedWorld,
+      world,
       activeCall,
       canvasRef,
-      onEnteredWorld,
       onLeftWorld,
     }),
-    [loadedWorld, activeCall, canvasRef, onEnteredWorld, onLeftWorld]
+    [world, activeCall, canvasRef, onLeftWorld]
   );
 
-  const { isEnteredWorld } = useStore.getState().world;
+  const isEnteredWorld = useStore((state) => state.world.isEnteredWorld);
+
   return (
     <div className="SessionView">
       <canvas className="SessionView__viewport" ref={canvasRef} />
       {engine ? (
         <EngineContextProvider value={engine}>
           <Outlet context={outletContext} />
-          {isOverlayOpen && <Overlay isHome={isHome} onEnterWorld={onEnterWorld} onLoadWorld={onLoadWorld} />}
-          <StatusBar showOverlayTip={!isHome && isEnteredWorld} title={isHome ? "Home" : loadedWorld?.name} />
+          {isOverlayOpen && <Overlay onLoadWorld={onLoadWorld} onEnterWorld={onEnterWorld} />}
+          <StatusBar showOverlayTip={isEnteredWorld} title={isHome ? "Home" : world?.name} />
         </EngineContextProvider>
       ) : (
         <div>Initializing engine...</div>

--- a/src/ui/views/session/statusbar/StatusBar.tsx
+++ b/src/ui/views/session/statusbar/StatusBar.tsx
@@ -1,5 +1,5 @@
 import { Text } from "../../../atoms/text/Text";
-import { closeOverlay, closeWorldChat, openOverlay, useStore } from "../../../hooks/useStore";
+import { useStore } from "../../../hooks/useStore";
 import "./StatusBar.css";
 
 function OpenOverlayTip({ text, onClick }: { text: string; onClick: () => void }) {
@@ -19,7 +19,8 @@ interface StatusBarProps {
 }
 
 export function StatusBar({ showOverlayTip, title }: StatusBarProps) {
-  const isOverlayOpen = useStore((state) => state.overlay.isOpen);
+  const { isOpen: isOverlayOpen, closeOverlay, openOverlay } = useStore((state) => state.overlay);
+  const closeWorldChat = useStore((state) => state.worldChat.closeWorldChat);
 
   const handleTipClick = () => {
     if (isOverlayOpen) {

--- a/src/ui/views/session/world/WorldView.tsx
+++ b/src/ui/views/session/world/WorldView.tsx
@@ -9,53 +9,56 @@ import { useStore } from "../../../hooks/useStore";
 import { useKeyDown } from "../../../hooks/useKeyDown";
 import { usePointerLockChange } from "../../../hooks/usePointerLockChange";
 import { useEvent } from "../../../hooks/useEvent";
-import { closeWorldChat, closeOverlay, openOverlay, openWorldChat, setIsPointerLock } from "../../../hooks/useStore";
 import MicIC from "../../../../../res/ic/mic.svg";
 import HeadphoneIC from "../../../../../res/ic/headphone.svg";
 import LogoutIC from "../../../../../res/ic/logout.svg";
 import "./WorldView.css";
 
 export function WorldView() {
-  const { canvasRef, loadedWorld, onLeftWorld } = useOutletContext<SessionOutletContext>();
+  const { canvasRef, world, onLeftWorld } = useOutletContext<SessionOutletContext>();
   const isEnteredWorld = useStore((state) => state.world.isEnteredWorld);
-  const isChatOpen = useStore((state) => state.world.isChatOpen);
+  const { isOpen: isChatOpen, openWorldChat, closeWorldChat } = useStore((state) => state.worldChat);
+  const setIsPointerLock = useStore((state) => state.pointerLock.setIsPointerLock);
+  const { isOpen: isOverlayOpen, openOverlay, closeOverlay } = useStore((state) => state.overlay);
 
-  useKeyDown((e) => {
-    const { isChatOpen, isEnteredWorld } = useStore.getState().world;
-    const { isOpen: isOverlayOpen } = useStore.getState().overlay;
-    if (isEnteredWorld === false) return;
-    const isEscape = e.key === "Escape";
+  useKeyDown(
+    (e) => {
+      if (isEnteredWorld === false) return;
+      const isEscape = e.key === "Escape";
 
-    if (isEscape && isChatOpen) {
-      canvasRef.current?.requestPointerLock();
-      closeWorldChat();
-      return;
-    }
-    if (isEscape && isOverlayOpen === false) {
-      document.exitPointerLock();
-      openOverlay();
-      return;
-    }
-    if (isEscape && isOverlayOpen) {
-      canvasRef.current?.requestPointerLock();
-      closeOverlay();
-      return;
-    }
-    if (e.key === "Enter" && isOverlayOpen === false && isChatOpen === false) {
-      document.exitPointerLock();
-      openWorldChat();
-      return;
-    }
-    if (e.altKey && e.code === "KeyL") {
-      onLeftWorld();
-    }
-  }, []);
+      if (isEscape && isChatOpen) {
+        canvasRef.current?.requestPointerLock();
+        closeWorldChat();
+        return;
+      }
+      if (isEscape && isOverlayOpen === false) {
+        document.exitPointerLock();
+        openOverlay();
+        return;
+      }
+      if (isEscape && isOverlayOpen) {
+        canvasRef.current?.requestPointerLock();
+        closeOverlay();
+        return;
+      }
+      if (e.key === "Enter" && isOverlayOpen === false && isChatOpen === false) {
+        document.exitPointerLock();
+        openWorldChat();
+        return;
+      }
+      if (e.altKey && e.code === "KeyL") {
+        onLeftWorld();
+      }
+    },
+    [isEnteredWorld, isChatOpen, isOverlayOpen, openWorldChat, closeWorldChat, openOverlay, closeOverlay]
+  );
 
   useEvent(
     "click",
     (e) => {
-      const { isChatOpen, isEnteredWorld } = useStore.getState().world;
-      const { isOpen: isOverlayOpen } = useStore.getState().overlay;
+      const isChatOpen = useStore.getState().worldChat.isOpen;
+      const isOverlayOpen = useStore.getState().overlay.isOpen;
+      const isEnteredWorld = useStore.getState().world.isEnteredWorld;
       if (isEnteredWorld === false) return;
 
       canvasRef.current?.requestPointerLock();
@@ -68,7 +71,7 @@ export function WorldView() {
 
   usePointerLockChange(canvasRef.current, setIsPointerLock, []);
 
-  if (isEnteredWorld === false || loadedWorld === undefined) {
+  if (isEnteredWorld === false || world === undefined) {
     return null;
   }
 
@@ -99,9 +102,9 @@ export function WorldView() {
     <div className="WorldView">
       <Stats />
       <div className="WorldView__chat flex">
-        <WorldChat open={isChatOpen} room={loadedWorld} />
+        <WorldChat open={isChatOpen} room={world} />
       </div>
-      {loadedWorld && renderControl()}
+      {world && renderControl()}
     </div>
   );
 }


### PR DESCRIPTION
This PR is some additional refactoring of @ajbura's last PR.

- Moved from module scoped actions to actions on the state object based on some of the best practices mentioned in the Zustand docs
- Further split out state into slices so that state selectors are easier to write and only select the state you actually want to update your view
- Added some additional logic around room creation / initial room loading / room preview that fixes a few edge cases