### PR TITLE
Disable Spaces bar and remove Settings tab

### DIFF
--- a/src/ui/hooks/useStore.ts
+++ b/src/ui/hooks/useStore.ts
@@ -7,7 +7,6 @@ export enum RoomListTabs {
   Worlds = "Worlds",
   Chats = "Chats",
   Friends = "Friends",
-  Settings = "Settings",
 }
 
 export enum OverlayWindow {

--- a/src/ui/views/session/overlay/Overlay.tsx
+++ b/src/ui/views/session/overlay/Overlay.tsx
@@ -41,7 +41,7 @@ export function Overlay({ onLoadWorld, onEnterWorld }: OverlayProps) {
   return (
     <div className={classNames("Overlay", { "Overlay--no-bg": !isEnteredWorld }, "flex items-end")}>
       <SidebarView
-        spaces={spacesEnabled && <SpacesView />}
+        spaces={spacesEnabled ? <SpacesView /> : undefined}
         roomList={
           selectedWindow ? undefined : (
             <RoomListView

--- a/src/ui/views/session/overlay/Overlay.tsx
+++ b/src/ui/views/session/overlay/Overlay.tsx
@@ -40,10 +40,10 @@ export function Overlay({ onLoadWorld, onEnterWorld }: OverlayProps) {
 
   return (
     <div className={classNames("Overlay", { "Overlay--no-bg": !isEnteredWorld }, "flex items-end")}>
-      <SidebarView
-        spaces={spacesEnabled ? <SpacesView /> : undefined}
-        roomList={
-          selectedWindow ? undefined : (
+      {selectedWindow ? undefined : (
+        <SidebarView
+          spaces={spacesEnabled ? <SpacesView /> : undefined}
+          roomList={
             <RoomListView
               header={<RoomListHeader selectedTab={selectedRoomListTab} onTabSelect={selectRoomListTab} />}
               content={
@@ -55,9 +55,9 @@ export function Overlay({ onLoadWorld, onEnterWorld }: OverlayProps) {
                 </RoomListContent>
               }
             />
-          )
-        }
-      />
+          }
+        />
+      )}
       {selectedWindow ? (
         <div className="Overlay__window grow flex">
           {selectedWindow === OverlayWindow.CreateWorld && <CreateWorld />}

--- a/src/ui/views/session/overlay/Overlay.tsx
+++ b/src/ui/views/session/overlay/Overlay.tsx
@@ -36,11 +36,12 @@ export function Overlay({ onLoadWorld, onEnterWorld }: OverlayProps) {
   const isEnteredWorld = useStore((state) => state.world.isEnteredWorld);
   const selectedChat = useRoom(session, selectedChatId);
   const { selectedWindow } = useStore((state) => state.overlayWindow);
+  const spacesEnabled = false;
 
   return (
     <div className={classNames("Overlay", { "Overlay--no-bg": !isEnteredWorld }, "flex items-end")}>
       <SidebarView
-        spaces={<SpacesView />}
+        spaces={spacesEnabled && <SpacesView />}
         roomList={
           selectedWindow ? undefined : (
             <RoomListView

--- a/src/ui/views/session/overlay/WorldPreview.tsx
+++ b/src/ui/views/session/overlay/WorldPreview.tsx
@@ -156,8 +156,8 @@ export function WorldPreview({ session, onLoadWorld, onEnterWorld }: IWorldPrevi
         }
 
         if (roomStatus & RoomStatus.BeingCreated) return <WorldPreviewCard title="Creating Room..." />;
-        if (roomStatus & RoomStatus.Invited) <WorldPreviewCard title="Invited To Room" />;
-        if (roomStatus & RoomStatus.Archived) <WorldPreviewCard title="Room Archived" />;
+        if (roomStatus & RoomStatus.Invited) return <WorldPreviewCard title="Invited To Room" />;
+        if (roomStatus & RoomStatus.Archived) return <WorldPreviewCard title="Room Archived" />;
 
         if (roomStatus & RoomStatus.Joined) {
           return (

--- a/src/ui/views/session/sidebar/RoomListHeader.tsx
+++ b/src/ui/views/session/sidebar/RoomListHeader.tsx
@@ -9,7 +9,6 @@ import HomeIC from "../../../../../res/ic/home.svg";
 import LanguageIC from "../../../../../res/ic/language.svg";
 import ChatIC from "../../../../../res/ic/chat.svg";
 import PeoplesIC from "../../../../../res/ic/peoples.svg";
-import SettingIC from "../../../../../res/ic/setting.svg";
 import "./RoomListHeader.css";
 
 interface IRoomListHeader {
@@ -65,12 +64,6 @@ export function RoomListHeader({ selectedTab, onTabSelect }: IRoomListHeader) {
         iconSrc={PeoplesIC}
         isActive={selectedTab === RoomListTabs.Friends}
         onClick={() => onTabSelect(RoomListTabs.Friends)}
-      />
-      <RoomListTab
-        name="Settings"
-        iconSrc={SettingIC}
-        isActive={selectedTab === RoomListTabs.Settings}
-        onClick={() => onTabSelect(RoomListTabs.Settings)}
       />
     </header>
   );

--- a/src/ui/views/session/sidebar/SidebarView.tsx
+++ b/src/ui/views/session/sidebar/SidebarView.tsx
@@ -4,7 +4,7 @@ import classNames from "classnames";
 import "./SidebarView.css";
 
 interface SidebarViewProps {
-  spaces: ReactNode;
+  spaces?: ReactNode;
   roomList?: ReactNode;
 }
 
@@ -13,7 +13,7 @@ export function SidebarView({ spaces, roomList }: SidebarViewProps) {
 
   return (
     <div className={sidebarClass}>
-      <div className="shrink-0 flex">{spaces}</div>
+      {spaces && <div className="shrink-0 flex">{spaces}</div>}
       {roomList && <div className="grow flex">{roomList}</div>}
     </div>
   );


### PR DESCRIPTION
This PR disables the Spaces bar while we're waiting on spaces support in Hydrogen and a proper "Explore" page for Third Room. We'll likely bring it back when it's ready. For now, I've disabled it.

I also removed the settings tab completely. I think we should move this under the user dropdown menu. It already has logout and profile options there. Let's move settings under there as well.