### PR TITLE
Fix loading tiles from relative url

### DIFF
--- a/src/engine/gltf/MX_tiles_renderer.ts
+++ b/src/engine/gltf/MX_tiles_renderer.ts
@@ -1,9 +1,9 @@
 import { createRemoteTilesRenderer } from "../tiles-renderer/tiles-renderer.game";
 import { GameState } from "../GameTypes";
 import { RemoteNodeComponent } from "../node/node.game";
-//import resolveURL from "../utils/resolveURL";
 import { GLTFNode } from "./GLTF";
 import { GLTFResource } from "./gltf.game";
+import resolveURL from "../utils/resolveURL";
 
 export function hasTilesRendererExtension(node: GLTFNode) {
   return node.extensions?.MX_tiles_renderer !== undefined;
@@ -17,5 +17,7 @@ export function addTilesRenderer(ctx: GameState, resource: GLTFResource, nodeInd
     return;
   }
 
-  remoteNode.tilesRenderer = createRemoteTilesRenderer(ctx, "/gltf/mars/tiles/scene-tileset.json");
+  const tilesetUrl = node.extensions.MX_tiles_renderer.tilesetUrl;
+
+  remoteNode.tilesRenderer = createRemoteTilesRenderer(ctx, resolveURL(tilesetUrl, resource.baseUrl));
 }


### PR DESCRIPTION
I missed one thing in the last PR. This fixes loading tiles from a relative url rather than the hardcoded path I had in there.