### PR TITLE
Downgrade 3d-tiles-renderer to v0.3.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "3d-tiles-renderer": "https://github.com/matrix-org/3DTilesRendererJS.git#basic-typescript-types",
+    "3d-tiles-renderer": "https://github.com/matrix-org/3DTilesRendererJS.git#v0.3.9-patch",
     "@dimforge/rapier3d-compat": "0.7.6",
     "@radix-ui/react-dialog": "^0.1.7",
     "@radix-ui/react-dropdown-menu": "^0.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,9 +9,11 @@
   dependencies:
     path-browserify "^1.0.1"
 
-"3d-tiles-renderer@https://github.com/matrix-org/3DTilesRendererJS.git#basic-typescript-types":
+"3d-tiles-renderer@https://github.com/matrix-org/3DTilesRendererJS.git#v0.3.9-patch":
   version "0.3.9"
-  resolved "https://github.com/matrix-org/3DTilesRendererJS.git#10c43ca7cd1e72c90430496e8b149dbd4bcef5bb"
+  resolved "https://github.com/matrix-org/3DTilesRendererJS.git#0a24d695752f6e419d47cca0bbec0e8ba8f0af4c"
+  dependencies:
+    path-browserify "^1.0.1"
 
 "@ampproject/remapping@^2.1.0":
   version "2.1.2"


### PR DESCRIPTION
There were some issues with basing my changes to 3d-tiles-renderer on the main branch so I've downgraded and things seem to be working much better