### PR TITLE
Add support for the EXT_mesh_gpu_instancing extension

### DIFF
--- a/src/engine/gltf/GLTF.ts
+++ b/src/engine/gltf/GLTF.ts
@@ -760,3 +760,12 @@ export enum GLTFLightType {
   Point = "point",
   Spot = "spot",
 }
+
+export interface GLTFInstancedMeshExtension {
+  /**
+   * A plain JSON object, where each key corresponds to a mesh attribute semantic and each value is the index of the accessor containing attribute's data.
+   */
+  attributes: {
+    [k: string]: GLTFId;
+  };
+}

--- a/src/engine/mesh/mesh.common.ts
+++ b/src/engine/mesh/mesh.common.ts
@@ -3,6 +3,7 @@ import { ResourceId } from "../resource/resource.common";
 
 export const MeshResourceType = "mesh";
 export const MeshPrimitiveResourceType = "mesh-primitive";
+export const InstancedMeshResourceType = "instanced-mesh";
 
 export interface PrimitiveResourceProps {
   attributes: { [key: string]: ResourceId };
@@ -16,6 +17,10 @@ export interface MeshResourceProps {
 
 export interface SharedMeshResource {
   initialProps: MeshResourceProps;
+}
+
+export interface SharedInstancedMeshResource {
+  attributes: { [key: string]: ResourceId };
 }
 
 export const meshPrimitiveSchema = defineObjectBufferSchema({
@@ -48,4 +53,10 @@ export enum MeshPrimitiveAttribute {
   COLOR_0 = "COLOR_0",
   JOINTS_0 = "JOINTS_0",
   WEIGHTS_0 = "WEIGHTS_0",
+}
+
+export enum InstancedMeshAttribute {
+  TRANSLATION = "TRANSLATION",
+  ROTATION = "ROTATION",
+  SCALE = "SCALE",
 }

--- a/src/engine/mesh/mesh.game.ts
+++ b/src/engine/mesh/mesh.game.ts
@@ -20,6 +20,8 @@ import {
   SharedMeshPrimitiveResource,
   MeshPrimitiveResourceType,
   MeshPrimitiveTripleBuffer,
+  InstancedMeshResourceType,
+  SharedInstancedMeshResource,
 } from "./mesh.common";
 
 export type MeshPrimitiveBufferView = ObjectBufferView<typeof meshPrimitiveSchema, ArrayBuffer>;
@@ -45,6 +47,11 @@ export interface MeshPrimitiveProps {
   indices?: RemoteAccessor<any, any>;
   material?: RemoteMaterial;
   mode?: number;
+}
+
+export interface RemoteInstancedMesh {
+  resourceId: number;
+  attributes: { [key: string]: RemoteAccessor<any, any> };
 }
 
 export function createRemoteMesh(ctx: GameState, primitives: MeshPrimitiveProps | MeshPrimitiveProps[]): RemoteMesh {
@@ -110,6 +117,32 @@ function createRemoteMeshPrimitive(ctx: GameState, props: MeshPrimitiveProps): R
   rendererModule.meshPrimitives.push(remoteMeshPrimitive);
 
   return remoteMeshPrimitive;
+}
+
+export function createRemoteInstancedMesh(
+  ctx: GameState,
+  attributes: { [key: string]: RemoteAccessor<any, any> }
+): RemoteInstancedMesh {
+  const sharedResource: SharedInstancedMeshResource = {
+    attributes: Object.fromEntries(
+      Object.entries(attributes).map(([name, accessor]: [string, RemoteAccessor<any, any>]) => [
+        name,
+        accessor.resourceId,
+      ])
+    ),
+  };
+
+  const resourceId = createResource<SharedInstancedMeshResource>(
+    ctx,
+    Thread.Render,
+    InstancedMeshResourceType,
+    sharedResource
+  );
+
+  return {
+    resourceId,
+    attributes,
+  };
 }
 
 export function updateRemoteMeshPrimitives(meshPrimitives: RemoteMeshPrimitive[]) {

--- a/src/engine/node/node.common.ts
+++ b/src/engine/node/node.common.ts
@@ -7,6 +7,7 @@ export const rendererNodeSchema = defineObjectBufferSchema({
   static: [Uint8Array, 1],
   worldMatrix: [Float32Array, 16],
   mesh: [Uint32Array, 1],
+  instancedMesh: [Uint32Array, 1],
   light: [Uint32Array, 1],
   camera: [Uint32Array, 1],
   tilesRenderer: [Uint32Array, 1],

--- a/src/engine/node/node.game.ts
+++ b/src/engine/node/node.game.ts
@@ -11,7 +11,7 @@ import { RemoteCamera } from "../camera/camera.game";
 import { Hidden, Transform, traverse } from "../component/transform";
 import { GameState } from "../GameTypes";
 import { RemoteLight } from "../light/light.game";
-import { RemoteMesh } from "../mesh/mesh.game";
+import { RemoteMesh, RemoteInstancedMesh } from "../mesh/mesh.game";
 import { Thread } from "../module/module.common";
 import { ResourceId } from "../resource/resource.common";
 import { createResource, disposeResource } from "../resource/resource.game";
@@ -40,6 +40,8 @@ export interface RemoteNode {
   rendererNodeTripleBuffer: RendererNodeTripleBuffer;
   get mesh(): RemoteMesh | undefined;
   set mesh(mesh: RemoteMesh | undefined);
+  get instancedMesh(): RemoteInstancedMesh | undefined;
+  set instancedMesh(instancedMesh: RemoteInstancedMesh | undefined);
   get light(): RemoteLight | undefined;
   set light(light: RemoteLight | undefined);
   get camera(): RemoteCamera | undefined;
@@ -54,6 +56,7 @@ export interface RemoteNode {
 
 interface NodeProps {
   mesh?: RemoteMesh;
+  instancedMesh?: RemoteInstancedMesh;
   light?: RemoteLight;
   camera?: RemoteCamera;
   audioEmitter?: RemotePositionalAudioEmitter;
@@ -69,6 +72,7 @@ export function addRemoteNodeComponent(ctx: GameState, eid: number, props?: Node
     const remoteNode = RemoteNodeComponent.get(eid)!;
 
     if (props?.mesh) remoteNode.mesh = props.mesh;
+    if (props?.instancedMesh) remoteNode.instancedMesh = props.instancedMesh;
     if (props?.light) remoteNode.light = props.light;
     if (props?.camera) remoteNode.camera = props.camera;
     if (props?.audioEmitter) remoteNode.audioEmitter = props.audioEmitter;
@@ -81,6 +85,7 @@ export function addRemoteNodeComponent(ctx: GameState, eid: number, props?: Node
   const audioNodeBufferView = createObjectBufferView(audioNodeSchema, ArrayBuffer);
 
   rendererNodeBufferView.mesh[0] = props?.mesh?.resourceId || 0;
+  rendererNodeBufferView.instancedMesh[0] = props?.instancedMesh?.resourceId || 0;
   rendererNodeBufferView.light[0] = props?.light?.resourceId || 0;
   rendererNodeBufferView.camera[0] = props?.camera?.resourceId || 0;
   rendererNodeBufferView.tilesRenderer[0] = props?.tilesRenderer?.resourceId || 0;
@@ -102,6 +107,7 @@ export function addRemoteNodeComponent(ctx: GameState, eid: number, props?: Node
   });
 
   let _mesh: RemoteMesh | undefined = props?.mesh;
+  let _instancedMesh: RemoteInstancedMesh | undefined = props?.instancedMesh;
   let _light: RemoteLight | undefined = props?.light;
   let _camera: RemoteCamera | undefined = props?.camera;
   let _audioEmitter: RemotePositionalAudioEmitter | undefined = props?.audioEmitter;
@@ -121,6 +127,13 @@ export function addRemoteNodeComponent(ctx: GameState, eid: number, props?: Node
     set mesh(mesh: RemoteMesh | undefined) {
       _mesh = mesh;
       rendererNodeBufferView.mesh[0] = mesh?.resourceId || 0;
+    },
+    get instancedMesh() {
+      return _instancedMesh;
+    },
+    set instancedMesh(instancedMesh: RemoteInstancedMesh | undefined) {
+      _instancedMesh = instancedMesh;
+      rendererNodeBufferView.instancedMesh[0] = instancedMesh?.resourceId || 0;
     },
     get light() {
       return _light;

--- a/src/engine/node/node.render.ts
+++ b/src/engine/node/node.render.ts
@@ -1,4 +1,5 @@
 import {
+  InstancedMesh,
   Light,
   Line,
   LineLoop,
@@ -20,7 +21,7 @@ import { LocalCameraResource, updateNodeCamera } from "../camera/camera.render";
 import { clamp } from "../component/transform";
 import { tickRate } from "../config.common";
 import { LocalLightResource, updateNodeLight } from "../light/light.render";
-import { LocalMesh, updateNodeMesh } from "../mesh/mesh.render";
+import { LocalInstancedMesh, LocalMesh, updateNodeMesh } from "../mesh/mesh.render";
 import { getModule } from "../module/module.common";
 import { RendererModule, RendererModuleState, RenderThreadState } from "../renderer/renderer.render";
 import { ResourceId } from "../resource/resource.common";
@@ -31,12 +32,13 @@ import { LocalTilesRendererResource, updateNodeTilesRenderer } from "../tiles-re
 import { promiseObject } from "../utils/promiseObject";
 import { RendererNodeTripleBuffer, RendererSharedNodeResource } from "./node.common";
 
-type PrimitiveObject3D = Mesh | SkinnedMesh | Line | LineSegments | LineLoop | Points;
+type PrimitiveObject3D = Mesh | SkinnedMesh | Line | LineSegments | LineLoop | Points | InstancedMesh;
 
 export interface LocalNode {
   resourceId: ResourceId;
   rendererNodeTripleBuffer: RendererNodeTripleBuffer;
   mesh?: LocalMesh;
+  instancedMesh?: LocalInstancedMesh;
   meshPrimitiveObjects?: PrimitiveObject3D[];
   camera?: LocalCameraResource;
   cameraObject?: PerspectiveCamera | OrthographicCamera;
@@ -56,6 +58,9 @@ export async function onLoadLocalNode(
 
   const resources = await promiseObject({
     mesh: nodeView.mesh[0] ? waitForLocalResource<LocalMesh>(ctx, nodeView.mesh[0]) : undefined,
+    instancedMesh: nodeView.instancedMesh[0]
+      ? waitForLocalResource<LocalInstancedMesh>(ctx, nodeView.instancedMesh[0])
+      : undefined,
     camera: nodeView.camera[0] ? waitForLocalResource<LocalCameraResource>(ctx, nodeView.camera[0]) : undefined,
     light: nodeView.light[0] ? waitForLocalResource<LocalLightResource>(ctx, nodeView.light[0]) : undefined,
   });
@@ -64,6 +69,7 @@ export async function onLoadLocalNode(
     resourceId,
     rendererNodeTripleBuffer,
     mesh: resources.mesh,
+    instancedMesh: resources.instancedMesh,
     camera: resources.camera,
     light: resources.light,
   };

--- a/src/engine/renderer/renderer.render.ts
+++ b/src/engine/renderer/renderer.render.ts
@@ -53,11 +53,12 @@ import {
 import { OrthographicCameraResourceType, PerspectiveCameraResourceType } from "../camera/camera.common";
 import { AccessorResourceType } from "../accessor/accessor.common";
 import { onLoadLocalAccessorResource } from "../accessor/accessor.render";
-import { MeshPrimitiveResourceType, MeshResourceType } from "../mesh/mesh.common";
+import { InstancedMeshResourceType, MeshPrimitiveResourceType, MeshResourceType } from "../mesh/mesh.common";
 import {
   LocalMeshPrimitive,
   onLoadLocalMeshPrimitiveResource,
   onLoadLocalMeshResource,
+  onLoadLocalInstancedMeshResource,
   updateLocalMeshPrimitiveResources,
 } from "../mesh/mesh.render";
 import { LocalNode, onLoadLocalNode, updateLocalNodeResources } from "../node/node.render";
@@ -154,6 +155,7 @@ export const RendererModule = defineModule<RenderThreadState, RendererModuleStat
       registerResourceLoader(ctx, AccessorResourceType, onLoadLocalAccessorResource),
       registerResourceLoader(ctx, MeshResourceType, onLoadLocalMeshResource),
       registerResourceLoader(ctx, MeshPrimitiveResourceType, onLoadLocalMeshPrimitiveResource),
+      registerResourceLoader(ctx, InstancedMeshResourceType, onLoadLocalInstancedMeshResource),
       registerResourceLoader(ctx, NodeResourceType, onLoadLocalNode),
       registerResourceLoader(ctx, TilesRendererResourceType, onLoadTilesRenderer),
     ]);


### PR DESCRIPTION
This PR adds support for the [EXT_mesh_gpu_instancing](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/EXT_mesh_gpu_instancing) glTF extension. It allows for improved performance when rendering multiple of the same object.

This PR doesn't yet add collision support for instanced meshes (I'm not so sure we should). It also doesn't have support for skinned meshes or updating the properties of instanced meshes yet.