### PR TITLE
Properly dispose of resources

### DIFF
--- a/src/engine/bufferView/bufferView.game.ts
+++ b/src/engine/bufferView/bufferView.game.ts
@@ -4,33 +4,48 @@ import { createResource } from "../resource/resource.game";
 import { BufferViewResourceProps, BufferViewResourceType } from "./bufferView.common";
 
 export interface RemoteBufferView<T extends Thread> {
+  name: string;
   thread: T;
   resourceId: number;
   buffer: ArrayBuffer;
   byteStride: number;
 }
 
+interface BufferViewProps<T extends Thread> {
+  name?: string;
+  thread: T;
+  buffer: ArrayBuffer;
+  byteStride?: number;
+}
+
+const DEFAULT_BUFFER_VIEW_NAME = "Buffer View";
+
 export function createRemoteBufferView<T extends Thread>(
   ctx: GameState,
-  thread: T,
-  buffer: ArrayBuffer,
-  byteStride = 0
+  props: BufferViewProps<T>
 ): RemoteBufferView<T> {
+  const name = props.name || DEFAULT_BUFFER_VIEW_NAME;
+  const byteStride = props.byteStride || 0;
+
   const resourceId = createResource<BufferViewResourceProps>(
     ctx,
-    thread,
+    props.thread,
     BufferViewResourceType,
     {
-      buffer,
+      buffer: props.buffer,
       byteStride,
     },
-    [buffer]
+    {
+      name,
+      transferList: [props.buffer],
+    }
   );
 
   return {
-    thread,
+    name,
+    thread: props.thread,
     resourceId,
     byteStride,
-    buffer,
+    buffer: props.buffer,
   };
 }

--- a/src/engine/camera/camera.game.ts
+++ b/src/engine/camera/camera.game.ts
@@ -25,6 +25,7 @@ export type PerspectiveCameraBufferView = ObjectBufferView<typeof perspectiveCam
 export type OrthographicCameraBufferView = ObjectBufferView<typeof orthographicCameraSchema, ArrayBuffer>;
 
 export interface RemotePerspectiveCamera {
+  name: string;
   resourceId: ResourceId;
   type: CameraType.Perspective;
   cameraBufferView: PerspectiveCameraBufferView;
@@ -42,6 +43,7 @@ export interface RemotePerspectiveCamera {
 }
 
 export interface RemoteOrthographicCamera {
+  name: string;
   resourceId: ResourceId;
   type: CameraType.Orthographic;
   cameraBufferView: OrthographicCameraBufferView;
@@ -61,12 +63,15 @@ export interface RemoteOrthographicCamera {
 export type RemoteCamera = RemotePerspectiveCamera | RemoteOrthographicCamera;
 
 export interface PerspectiveCameraProps {
+  name?: string;
   layers?: number;
   aspectRatio?: number;
   yfov: number;
   zfar?: number;
   znear: number;
 }
+
+const DEFAULT_PERSPECTIVE_CAMERA_NAME = "Perspective Camera";
 
 export function createRemotePerspectiveCamera(ctx: GameState, props?: PerspectiveCameraProps): RemotePerspectiveCamera {
   const rendererModule = getModule(ctx, RendererModule);
@@ -82,6 +87,8 @@ export function createRemotePerspectiveCamera(ctx: GameState, props?: Perspectiv
 
   const cameraTripleBuffer = createObjectTripleBuffer(perspectiveCameraSchema, ctx.gameToMainTripleBufferFlags);
 
+  const name = props?.name || DEFAULT_PERSPECTIVE_CAMERA_NAME;
+
   const resourceId = createResource<SharedPerspectiveCameraResource>(
     ctx,
     Thread.Render,
@@ -89,10 +96,14 @@ export function createRemotePerspectiveCamera(ctx: GameState, props?: Perspectiv
     {
       type: CameraType.Perspective,
       cameraTripleBuffer,
+    },
+    {
+      name,
     }
   );
 
   const remoteCamera: RemotePerspectiveCamera = {
+    name,
     resourceId,
     cameraBufferView,
     cameraTripleBuffer,
@@ -139,12 +150,15 @@ export function createRemotePerspectiveCamera(ctx: GameState, props?: Perspectiv
 }
 
 export interface OrthographicCameraProps {
+  name?: string;
   layers?: number;
   xmag: number;
   ymag: number;
   zfar: number;
   znear: number;
 }
+
+const DEFAULT_ORTHOGRAPHIC_CAMERA_NAME = "Orthographic Camera";
 
 export function createRemoteOrthographicCamera(
   ctx: GameState,
@@ -162,6 +176,8 @@ export function createRemoteOrthographicCamera(
 
   const cameraTripleBuffer = createObjectTripleBuffer(orthographicCameraSchema, ctx.gameToMainTripleBufferFlags);
 
+  const name = props.name || DEFAULT_ORTHOGRAPHIC_CAMERA_NAME;
+
   const resourceId = createResource<SharedOrthographicCameraResource>(
     ctx,
     Thread.Render,
@@ -169,10 +185,14 @@ export function createRemoteOrthographicCamera(
     {
       type: CameraType.Orthographic,
       cameraTripleBuffer,
+    },
+    {
+      name,
     }
   );
 
   const remoteCamera: RemoteOrthographicCamera = {
+    name,
     resourceId,
     cameraBufferView,
     cameraTripleBuffer,

--- a/src/engine/component/transform.ts
+++ b/src/engine/component/transform.ts
@@ -1,4 +1,4 @@
-import { addComponent, addEntity, defineComponent, IComponent, removeComponent } from "bitecs";
+import { addComponent, addEntity, defineComponent, IComponent, removeComponent, removeEntity } from "bitecs";
 import { vec3, quat, mat4 } from "gl-matrix";
 
 import { maxEntities, NOOP } from "../config.common";
@@ -455,6 +455,21 @@ export function traverse(rootEid: number, callback: (eid: number) => unknown | f
       eid = Transform.nextSibling[eid];
     }
   }
+}
+
+export function traverseReverse(rootEid: number, callback: (eid: number) => unknown) {
+  const stack: number[] = [];
+  traverse(rootEid, (eid) => stack.push(eid));
+
+  while (stack.length) {
+    callback(stack.pop()!);
+  }
+}
+
+export function removeRecursive(world: World, rootEid: number) {
+  traverseReverse(rootEid, (eid) => {
+    removeEntity(world, eid);
+  });
 }
 
 export function* getChildren(parentEid: number): Generator<number, number> {

--- a/src/engine/gltf/MX_tiles_renderer.ts
+++ b/src/engine/gltf/MX_tiles_renderer.ts
@@ -19,5 +19,5 @@ export function addTilesRenderer(ctx: GameState, resource: GLTFResource, nodeInd
 
   const tilesetUrl = node.extensions.MX_tiles_renderer.tilesetUrl;
 
-  remoteNode.tilesRenderer = createRemoteTilesRenderer(ctx, resolveURL(tilesetUrl, resource.baseUrl));
+  remoteNode.tilesRenderer = createRemoteTilesRenderer(ctx, { tilesetUrl: resolveURL(tilesetUrl, resource.baseUrl) });
 }

--- a/src/engine/light/light.common.ts
+++ b/src/engine/light/light.common.ts
@@ -1,7 +1,7 @@
 import { defineObjectBufferSchema, ObjectTripleBuffer } from "../allocator/ObjectBufferView";
 
-export const DirectionalLightResourceType = "point-light";
-export const PointLightResourceType = "directional-light";
+export const DirectionalLightResourceType = "directional-light";
+export const PointLightResourceType = "point-light";
 export const SpotLightResourceType = "spot-light";
 
 export const directionalLightSchema = defineObjectBufferSchema({

--- a/src/engine/light/light.game.ts
+++ b/src/engine/light/light.game.ts
@@ -32,6 +32,7 @@ export type PointLightBufferView = ObjectBufferView<typeof pointLightSchema, Arr
 export type SpotLightBufferView = ObjectBufferView<typeof spotLightSchema, ArrayBuffer>;
 
 export interface RemoteDirectionalLight {
+  name: string;
   resourceId: ResourceId;
   type: LightType.Directional;
   lightBufferView: DirectionalLightBufferView;
@@ -45,6 +46,7 @@ export interface RemoteDirectionalLight {
 }
 
 export interface RemotePointLight {
+  name: string;
   resourceId: ResourceId;
   type: LightType.Point;
   lightBufferView: PointLightBufferView;
@@ -60,6 +62,7 @@ export interface RemotePointLight {
 }
 
 export interface RemoteSpotLight {
+  name: string;
   resourceId: ResourceId;
   type: LightType.Spot;
   lightBufferView: SpotLightBufferView;
@@ -102,10 +105,13 @@ export function updateRemoteRemoteSpotLights(spotLights: RemoteSpotLight[]) {
 }
 
 export interface DirectionalLightProps {
+  name?: string;
   color?: vec3;
   intensity?: number;
   castShadow?: boolean;
 }
+
+const DEFAULT_DIRECTIONAL_LIGHT_NAME = "Directional Light";
 
 export function createDirectionalLightResource(ctx: GameState, props?: DirectionalLightProps): RemoteDirectionalLight {
   const rendererModule = getModule(ctx, RendererModule);
@@ -118,12 +124,23 @@ export function createDirectionalLightResource(ctx: GameState, props?: Direction
 
   const lightTripleBuffer = createObjectTripleBuffer(directionalLightSchema, ctx.gameToMainTripleBufferFlags);
 
-  const resourceId = createResource<SharedDirectionalLightResource>(ctx, Thread.Render, DirectionalLightResourceType, {
-    type: LightType.Directional,
-    lightTripleBuffer,
-  });
+  const name = props?.name || DEFAULT_DIRECTIONAL_LIGHT_NAME;
+
+  const resourceId = createResource<SharedDirectionalLightResource>(
+    ctx,
+    Thread.Render,
+    DirectionalLightResourceType,
+    {
+      type: LightType.Directional,
+      lightTripleBuffer,
+    },
+    {
+      name,
+    }
+  );
 
   const remoteLight: RemoteDirectionalLight = {
+    name,
     resourceId,
     lightBufferView,
     lightTripleBuffer,
@@ -154,11 +171,14 @@ export function createDirectionalLightResource(ctx: GameState, props?: Direction
 }
 
 export interface PointLightProps {
+  name?: string;
   color?: vec3;
   intensity?: number;
   range?: number;
   castShadow?: boolean;
 }
+
+const DEFAULT_POINT_LIGHT_NAME = "Point Light";
 
 export function createPointLightResource(ctx: GameState, props?: PointLightProps): RemotePointLight {
   const rendererModule = getModule(ctx, RendererModule);
@@ -172,12 +192,23 @@ export function createPointLightResource(ctx: GameState, props?: PointLightProps
 
   const lightTripleBuffer = createObjectTripleBuffer(pointLightSchema, ctx.gameToMainTripleBufferFlags);
 
-  const resourceId = createResource<SharedPointLightResource>(ctx, Thread.Render, PointLightResourceType, {
-    type: LightType.Point,
-    lightTripleBuffer,
-  });
+  const name = props?.name || DEFAULT_POINT_LIGHT_NAME;
+
+  const resourceId = createResource<SharedPointLightResource>(
+    ctx,
+    Thread.Render,
+    PointLightResourceType,
+    {
+      type: LightType.Point,
+      lightTripleBuffer,
+    },
+    {
+      name,
+    }
+  );
 
   const remoteLight: RemotePointLight = {
+    name,
     resourceId,
     lightBufferView,
     lightTripleBuffer,
@@ -214,6 +245,7 @@ export function createPointLightResource(ctx: GameState, props?: PointLightProps
 }
 
 export interface SpotLightProps {
+  name?: string;
   color?: vec3;
   intensity?: number;
   range?: number;
@@ -221,6 +253,8 @@ export interface SpotLightProps {
   outerConeAngle?: number;
   castShadow?: boolean;
 }
+
+const DEFAULT_SPOT_LIGHT_NAME = "Spot Light";
 
 export function createSpotLightResource(ctx: GameState, props?: SpotLightProps): RemoteSpotLight {
   const rendererModule = getModule(ctx, RendererModule);
@@ -237,12 +271,23 @@ export function createSpotLightResource(ctx: GameState, props?: SpotLightProps):
 
   const lightTripleBuffer = createObjectTripleBuffer(spotLightSchema, ctx.gameToMainTripleBufferFlags);
 
-  const resourceId = createResource<SharedSpotLightResource>(ctx, Thread.Render, SpotLightResourceType, {
-    type: LightType.Spot,
-    lightTripleBuffer,
-  });
+  const name = props?.name || DEFAULT_SPOT_LIGHT_NAME;
+
+  const resourceId = createResource<SharedSpotLightResource>(
+    ctx,
+    Thread.Render,
+    SpotLightResourceType,
+    {
+      type: LightType.Spot,
+      lightTripleBuffer,
+    },
+    {
+      name,
+    }
+  );
 
   const remoteLight: RemoteSpotLight = {
+    name,
     resourceId,
     lightBufferView,
     lightTripleBuffer,

--- a/src/engine/network/network.game.ts
+++ b/src/engine/network/network.game.ts
@@ -674,7 +674,7 @@ export function deserializePlayerNetworkId(input: NetPipeData) {
     remoteNode.audioEmitter = createRemotePositionalAudioEmitter(state, {
       sources: [
         createRemoteMediaStreamSource(state, {
-          stream: createRemoteMediaStream(state, peerId),
+          stream: createRemoteMediaStream(state, { streamId: peerId }),
         }),
       ],
     });

--- a/src/engine/node/node.game.ts
+++ b/src/engine/node/node.game.ts
@@ -162,7 +162,6 @@ export function addRemoteNodeComponent(ctx: GameState, eid: number, props?: Node
   );
 
   if (_mesh) {
-    console.log(`addRemoteNode mesh ${eid} ${_mesh.resourceId}`);
     addResourceRef(ctx, _mesh.resourceId);
   }
 

--- a/src/engine/prefab/index.ts
+++ b/src/engine/prefab/index.ts
@@ -33,46 +33,50 @@ export const createMesh = (ctx: GameState, geometry: BufferGeometry, material?: 
   const normal = addView(buffer, Float32Array, normArr.length, normArr);
   const uv = addView(buffer, Float32Array, uvArr.length, uvArr);
 
-  const bufferView = createRemoteBufferView(ctx, Thread.Render, buffer);
+  const bufferView = createRemoteBufferView(ctx, { thread: Thread.Render, buffer });
 
   const remoteMesh = createRemoteMesh(ctx, {
-    indices: createRemoteAccessor(ctx, {
-      type: AccessorType.SCALAR,
-      componentType: AccessorComponentType.Uint16,
-      bufferView,
-      count: indices.length,
-    }),
-    attributes: {
-      [MeshPrimitiveAttribute.POSITION]: createRemoteAccessor(ctx, {
-        type: AccessorType.VEC3,
-        componentType: AccessorComponentType.Float32,
-        bufferView,
-        byteOffset: position.byteOffset,
-        count: position.length / 3,
-      }),
-      [MeshPrimitiveAttribute.NORMAL]: createRemoteAccessor(ctx, {
-        type: AccessorType.VEC3,
-        componentType: AccessorComponentType.Float32,
-        bufferView,
-        byteOffset: normal.byteOffset,
-        count: normal.length / 3,
-        normalized: true,
-      }),
-      [MeshPrimitiveAttribute.TEXCOORD_0]: createRemoteAccessor(ctx, {
-        type: AccessorType.VEC2,
-        componentType: AccessorComponentType.Float32,
-        bufferView,
-        byteOffset: uv.byteOffset,
-        count: uv.length / 2,
-      }),
-    },
-    material:
-      material ||
-      createRemoteStandardMaterial(ctx, {
-        baseColorFactor: [Math.random(), Math.random(), Math.random(), 1.0],
-        roughnessFactor: 0.8,
-        metallicFactor: 0.8,
-      }),
+    primitives: [
+      {
+        indices: createRemoteAccessor(ctx, {
+          type: AccessorType.SCALAR,
+          componentType: AccessorComponentType.Uint16,
+          bufferView,
+          count: indices.length,
+        }),
+        attributes: {
+          [MeshPrimitiveAttribute.POSITION]: createRemoteAccessor(ctx, {
+            type: AccessorType.VEC3,
+            componentType: AccessorComponentType.Float32,
+            bufferView,
+            byteOffset: position.byteOffset,
+            count: position.length / 3,
+          }),
+          [MeshPrimitiveAttribute.NORMAL]: createRemoteAccessor(ctx, {
+            type: AccessorType.VEC3,
+            componentType: AccessorComponentType.Float32,
+            bufferView,
+            byteOffset: normal.byteOffset,
+            count: normal.length / 3,
+            normalized: true,
+          }),
+          [MeshPrimitiveAttribute.TEXCOORD_0]: createRemoteAccessor(ctx, {
+            type: AccessorType.VEC2,
+            componentType: AccessorComponentType.Float32,
+            bufferView,
+            byteOffset: uv.byteOffset,
+            count: uv.length / 2,
+          }),
+        },
+        material:
+          material ||
+          createRemoteStandardMaterial(ctx, {
+            baseColorFactor: [Math.random(), Math.random(), Math.random(), 1.0],
+            roughnessFactor: 0.8,
+            metallicFactor: 0.8,
+          }),
+      },
+    ],
   });
 
   return remoteMesh;

--- a/src/engine/resource/resource.game.ts
+++ b/src/engine/resource/resource.game.ts
@@ -34,6 +34,8 @@ interface ResourceModuleState {
   renderThreadTransferList: Transferable[];
 }
 
+class ResourceDisposedError extends Error {}
+
 export const ResourceModule = defineModule<GameState, ResourceModuleState>({
   name: "resource",
   create() {
@@ -137,6 +139,14 @@ export function createResource<Props>(
 
   const deferred = createDeferred<undefined>();
 
+  deferred.promise.catch((error) => {
+    if (error instanceof ResourceDisposedError) {
+      return;
+    }
+
+    console.error(error);
+  });
+
   resourceModule.deferredResources.set(id, deferred);
 
   const message = {
@@ -195,7 +205,7 @@ export function disposeResource(ctx: GameState, resourceId: ResourceId): boolean
   const deferred = resourceModule.deferredResources.get(resourceId);
 
   if (deferred) {
-    deferred.reject(new Error("Resource disposed"));
+    deferred.reject(new ResourceDisposedError("Resource disposed"));
     resourceModule.deferredResources.delete(resourceId);
   }
 

--- a/src/engine/sampler/sampler.game.ts
+++ b/src/engine/sampler/sampler.game.ts
@@ -12,10 +12,12 @@ import {
 } from "./sampler.common";
 
 export interface RemoteSampler {
+  name: string;
   resourceId: ResourceId;
 }
 
 export interface SamplerProps {
+  name?: string;
   magFilter?: SamplerMagFilter;
   minFilter?: SamplerMinFilter;
   wrapS?: SamplerWrap;
@@ -23,14 +25,27 @@ export interface SamplerProps {
   mapping?: SamplerMapping;
 }
 
+const DEFAULT_SAMPLER_NAME = "Sampler";
+
 export function createRemoteSampler(ctx: GameState, props: SamplerProps): RemoteSampler {
+  const name = props.name || DEFAULT_SAMPLER_NAME;
+
   return {
-    resourceId: createResource<SharedSamplerResource>(ctx, Thread.Render, SamplerResourceType, {
-      wrapS: props.wrapS || SamplerWrap.REPEAT,
-      wrapT: props.wrapT || SamplerWrap.REPEAT,
-      mapping: props.mapping === undefined ? SamplerMapping.UVMapping : props.mapping,
-      magFilter: props.magFilter,
-      minFilter: props.minFilter,
-    }),
+    name,
+    resourceId: createResource<SharedSamplerResource>(
+      ctx,
+      Thread.Render,
+      SamplerResourceType,
+      {
+        wrapS: props.wrapS || SamplerWrap.REPEAT,
+        wrapT: props.wrapT || SamplerWrap.REPEAT,
+        mapping: props.mapping === undefined ? SamplerMapping.UVMapping : props.mapping,
+        magFilter: props.magFilter,
+        minFilter: props.minFilter,
+      },
+      {
+        name,
+      }
+    ),
   };
 }

--- a/src/engine/scene/scene.game.ts
+++ b/src/engine/scene/scene.game.ts
@@ -11,7 +11,7 @@ import { GameState } from "../GameTypes";
 import { getModule, Thread } from "../module/module.common";
 import { RendererModule } from "../renderer/renderer.game";
 import { ResourceId } from "../resource/resource.common";
-import { createResource, disposeResource } from "../resource/resource.game";
+import { addResourceRef, createResource, disposeResource } from "../resource/resource.game";
 import { RemoteTexture } from "../texture/texture.game";
 import {
   audioSceneSchema,
@@ -26,7 +26,10 @@ import {
 export type RendererSceneBufferView = ObjectBufferView<typeof rendererSceneSchema, ArrayBuffer>;
 export type AudioSceneBufferView = ObjectBufferView<typeof audioSceneSchema, ArrayBuffer>;
 
+const DEFAULT_SCENE_NAME = "Scene";
+
 export interface RemoteScene {
+  name: string;
   eid: number;
   rendererResourceId: ResourceId;
   audioResourceId: ResourceId;
@@ -43,6 +46,7 @@ export interface RemoteScene {
 }
 
 export interface SceneProps {
+  name?: string;
   audioEmitters?: RemoteGlobalAudioEmitter[];
   backgroundTexture?: RemoteTexture;
   environmentTexture?: RemoteTexture;
@@ -64,19 +68,64 @@ export function addRemoteSceneComponent(ctx: GameState, eid: number, props?: Sce
 
   const rendererSceneTripleBuffer = createObjectTripleBuffer(rendererSceneSchema, ctx.gameToRenderTripleBufferFlags);
 
-  const rendererResourceId = createResource<RendererSharedSceneResource>(ctx, Thread.Render, SceneResourceType, {
-    rendererSceneTripleBuffer,
-  });
-
-  const audioResourceId = createResource<AudioSharedSceneResource>(ctx, Thread.Main, SceneResourceType, {
-    audioSceneTripleBuffer,
-  });
-
   let _backgroundTexture: RemoteTexture | undefined = props?.backgroundTexture;
   let _environmentTexture: RemoteTexture | undefined = props?.environmentTexture;
   let _audioEmitters: RemoteGlobalAudioEmitter[] = props?.audioEmitters || [];
 
+  const name = props?.name || DEFAULT_SCENE_NAME;
+
+  const rendererResourceId = createResource<RendererSharedSceneResource>(
+    ctx,
+    Thread.Render,
+    SceneResourceType,
+    {
+      rendererSceneTripleBuffer,
+    },
+    {
+      name,
+      dispose() {
+        if (_backgroundTexture) {
+          disposeResource(ctx, _backgroundTexture.resourceId);
+        }
+
+        if (_environmentTexture) {
+          disposeResource(ctx, _environmentTexture.resourceId);
+        }
+      },
+    }
+  );
+
+  const audioResourceId = createResource<AudioSharedSceneResource>(
+    ctx,
+    Thread.Main,
+    SceneResourceType,
+    {
+      audioSceneTripleBuffer,
+    },
+    {
+      name,
+      dispose() {
+        for (const audioEmitter of _audioEmitters) {
+          disposeResource(ctx, audioEmitter.resourceId);
+        }
+      },
+    }
+  );
+
+  if (_backgroundTexture) {
+    addResourceRef(ctx, _backgroundTexture.resourceId);
+  }
+
+  if (_environmentTexture) {
+    addResourceRef(ctx, _environmentTexture.resourceId);
+  }
+
+  for (const audioEmitter of _audioEmitters) {
+    addResourceRef(ctx, audioEmitter.resourceId);
+  }
+
   const remoteScene: RemoteScene = {
+    name,
     eid,
     rendererResourceId,
     audioResourceId,
@@ -88,6 +137,14 @@ export function addRemoteSceneComponent(ctx: GameState, eid: number, props?: Sce
       return _backgroundTexture;
     },
     set backgroundTexture(texture: RemoteTexture | undefined) {
+      if (texture) {
+        addResourceRef(ctx, texture.resourceId);
+      }
+
+      if (_backgroundTexture) {
+        disposeResource(ctx, _backgroundTexture.resourceId);
+      }
+
       _backgroundTexture = texture;
       rendererSceneBufferView.backgroundTexture[0] = texture ? texture.resourceId : 0;
     },
@@ -95,6 +152,14 @@ export function addRemoteSceneComponent(ctx: GameState, eid: number, props?: Sce
       return _environmentTexture;
     },
     set environmentTexture(texture: RemoteTexture | undefined) {
+      if (texture) {
+        addResourceRef(ctx, texture.resourceId);
+      }
+
+      if (_environmentTexture) {
+        disposeResource(ctx, _environmentTexture.resourceId);
+      }
+
       _environmentTexture = texture;
       rendererSceneBufferView.environmentTexture[0] = texture ? texture.resourceId : 0;
     },
@@ -102,6 +167,14 @@ export function addRemoteSceneComponent(ctx: GameState, eid: number, props?: Sce
       return _audioEmitters;
     },
     set audioEmitters(emitters: RemoteGlobalAudioEmitter[]) {
+      for (const audioEmitter of emitters) {
+        addResourceRef(ctx, audioEmitter.resourceId);
+      }
+
+      for (const audioEmitter of _audioEmitters) {
+        disposeResource(ctx, audioEmitter.resourceId);
+      }
+
       _audioEmitters = emitters;
       audioSceneBufferView.audioEmitters.set(emitters.map((e) => e.resourceId));
     },

--- a/src/engine/tiles-renderer/tiles-renderer.game.ts
+++ b/src/engine/tiles-renderer/tiles-renderer.game.ts
@@ -4,15 +4,34 @@ import { Thread } from "../module/module.common";
 import { TilesRendererResoruceProps, TilesRendererResourceType } from "./tiles-renderer.common";
 
 export interface RemoteTilesRenderer {
+  name: string;
   resourceId: number;
   tilesetUrl: string;
 }
 
-export function createRemoteTilesRenderer(ctx: GameState, tilesetUrl: string): RemoteTilesRenderer {
+const DEFAULT_TILES_RENDERER_NAME = "Tiles Renderer";
+
+export interface TilesRendererProps {
+  name?: string;
+  tilesetUrl: string;
+}
+
+export function createRemoteTilesRenderer(ctx: GameState, props: TilesRendererProps): RemoteTilesRenderer {
+  const name = props.name || DEFAULT_TILES_RENDERER_NAME;
+
   return {
-    tilesetUrl,
-    resourceId: createResource<TilesRendererResoruceProps>(ctx, Thread.Render, TilesRendererResourceType, {
-      tilesetUrl,
-    }),
+    name,
+    tilesetUrl: props.tilesetUrl,
+    resourceId: createResource<TilesRendererResoruceProps>(
+      ctx,
+      Thread.Render,
+      TilesRendererResourceType,
+      {
+        tilesetUrl: props.tilesetUrl,
+      },
+      {
+        name,
+      }
+    ),
   };
 }

--- a/src/plugins/CubeSpawner.ts
+++ b/src/plugins/CubeSpawner.ts
@@ -7,8 +7,8 @@ import {
   createRemoteAudioSource,
   playAudio,
   RemoteAudioSource,
-  addAudioEmitterComponent,
   RemoteAudioEmitter,
+  createRemotePositionalAudioEmitter,
 } from "../engine/audio/audio.game";
 import { Transform, addChild, addTransformComponent } from "../engine/component/transform";
 import { GameState } from "../engine/GameTypes";
@@ -44,14 +44,15 @@ export const CubeSpawnerModule = defineModule<GameState, CubeSpawnerModuleState>
   init(ctx) {
     const module = getModule(ctx, CubeSpawnerModule);
 
-    const image = createRemoteImage(ctx, "/image/crate.gif");
-    const texture = createRemoteTexture(ctx, image);
+    const image = createRemoteImage(ctx, { name: "Crate Image", uri: "/image/crate.gif" });
+    const texture = createRemoteTexture(ctx, { name: "Crate Texture", image });
 
     const cubeMaterial = createRemoteStandardMaterial(ctx, {
+      name: "Cube Material",
       baseColorTexture: texture,
     });
 
-    const crateAudioData = createRemoteAudioData(ctx, "/audio/hit.wav");
+    const crateAudioData = createRemoteAudioData(ctx, { name: "Crate Audio Data", uri: "/audio/hit.wav" });
 
     registerPrefab(ctx, {
       name: "crate",
@@ -64,7 +65,7 @@ export const CubeSpawnerModule = defineModule<GameState, CubeSpawnerModuleState>
           autoPlay: false,
         });
 
-        const audioEmitter = addAudioEmitterComponent(ctx, eid, {
+        const audioEmitter = createRemotePositionalAudioEmitter(ctx, {
           sources: [hitAudioSource],
         });
 
@@ -78,9 +79,10 @@ export const CubeSpawnerModule = defineModule<GameState, CubeSpawnerModuleState>
       },
     });
 
-    const ballAudioData = createRemoteAudioData(ctx, "/audio/bounce.wav");
+    const ballAudioData = createRemoteAudioData(ctx, { name: "Ball Audio Data", uri: "/audio/bounce.wav" });
 
     const ballMaterial = createRemoteStandardMaterial(ctx, {
+      name: "Ball Material",
       baseColorTexture: texture,
       baseColorFactor: [0.9, 0.5, 0.5, 1],
       occlusionTexture: texture,
@@ -101,7 +103,7 @@ export const CubeSpawnerModule = defineModule<GameState, CubeSpawnerModuleState>
           gain: 0,
         });
 
-        const audioEmitter = addAudioEmitterComponent(ctx, eid, {
+        const audioEmitter = createRemotePositionalAudioEmitter(ctx, {
           sources: [hitAudioSource],
         });
 

--- a/src/plugins/thirdroom/thirdroom.common.ts
+++ b/src/plugins/thirdroom/thirdroom.common.ts
@@ -4,6 +4,7 @@ export enum ThirdRoomMessageType {
   LoadEnvironment = "load-environment",
   EnvironmentLoaded = "environment-loaded",
   EnvironmentLoadError = "environment-load-error",
+  PrintResources = "print-resources",
 }
 
 export interface EnterWorldMessage {
@@ -31,4 +32,8 @@ export interface EnvironmentLoadErrorMessage {
   id: number;
   url: string;
   error: string;
+}
+
+export interface PrintResourcesMessage {
+  type: ThirdRoomMessageType.PrintResources;
 }

--- a/src/plugins/thirdroom/thirdroom.main.ts
+++ b/src/plugins/thirdroom/thirdroom.main.ts
@@ -2,6 +2,7 @@ import { IMainThreadContext } from "../../engine/MainThread";
 import { defineModule, getModule, registerMessageHandler, Thread } from "../../engine/module/module.common";
 import { createDisposables } from "../../engine/utils/createDisposables";
 import { createDeferred } from "../../engine/utils/Deferred";
+import { registerThirdroomGlobalFn } from "../../engine/utils/registerThirdroomGlobal";
 import {
   EnvironmentLoadedMessage,
   EnvironmentLoadErrorMessage,
@@ -21,7 +22,13 @@ export const ThirdroomModule = defineModule<IMainThreadContext, ThirdRoomModuleS
       loadEnvironmentMessageId: 0,
     };
   },
-  init() {},
+  init(ctx) {
+    registerThirdroomGlobalFn("printResources", () => {
+      ctx.sendMessage(Thread.Game, {
+        type: "print-resources",
+      });
+    });
+  },
 });
 
 export function loadEnvironment(ctx: IMainThreadContext, url: string) {

--- a/test/engine/component/transform.test.ts
+++ b/test/engine/component/transform.test.ts
@@ -7,6 +7,7 @@ import {
   addChild,
   removeChild,
   traverse,
+  traverseReverse,
 } from "../../../src/engine/component/transform";
 import { NOOP } from "../../../src/engine/config.common";
 
@@ -244,6 +245,46 @@ describe("Transform Unit Tests", function () {
 
         expect(results2).toStrictEqual([1, 2, 6, 7]);
       });
+    });
+  });
+
+  describe("traverseReverse", () => {
+    beforeEach(function () {
+      Transform.firstChild.fill(0);
+      Transform.prevSibling.fill(0);
+      Transform.nextSibling.fill(0);
+    });
+
+    test("should traverse with reverse ordering", () => {
+      /**
+       *       root(1)
+       *         / \
+       *      A(2) B(3)
+       *      /     / \
+       *    E(6)  C(4) D(5)
+       *    /
+       *   F(7)
+       */
+
+      const root = 1;
+      const childA = 2;
+      const childB = 3;
+      const childC = 4;
+      const childD = 5;
+      const childE = 6;
+      const childF = 7;
+      addChild(root, childA);
+      addChild(root, childB);
+      addChild(childB, childC);
+      addChild(childB, childD);
+      addChild(childA, childE);
+      addChild(childE, childF);
+
+      const result: number[] = [];
+
+      traverseReverse(1, (eid) => result.push(eid));
+
+      expect(result).toStrictEqual([5, 4, 3, 7, 6, 2, 1]);
     });
   });
 });


### PR DESCRIPTION
We're not properly disposing of resources across the various threads. This PR cleans up resources automatically when you remove entities they are attached to.

To Do:
- [ ] Investigate game thread memory usage hovering around 60mb
  - Could just be that the physics world has high overhead on top of our various component stores
- [ ] Total memory usage in the Chrome task manager is quite high while the GPU and JS heap is pretty reasonable. We should know where this is coming from.
- [ ] It looks like we're not disposing of some blobs for various images based on chrome://blob-internals/
  - Is this just room avatars/previews or is it also textures?
- [x] We're spitting out errors for a bunch of rejected promises when we leave a scene. I think we should catch these errors hand handle them silently.
- [ ] We still need to handle cleaning up Three.js resources like textures and geometries etc.
- [ ] There is also more work required to clean up audio resources
- [ ] `thirdroom.game.ts:258 RangeError: Maximum call stack size exceeded` when reloading UK City scene