### PR TITLE
Proper resource disposal when switching worlds

### DIFF
--- a/src/engine/bufferView/bufferView.game.ts
+++ b/src/engine/bufferView/bufferView.game.ts
@@ -7,14 +7,14 @@ export interface RemoteBufferView<T extends Thread> {
   name: string;
   thread: T;
   resourceId: number;
-  buffer: ArrayBuffer;
+  buffer?: SharedArrayBuffer;
   byteStride: number;
 }
 
 interface BufferViewProps<T extends Thread> {
   name?: string;
   thread: T;
-  buffer: ArrayBuffer;
+  buffer: ArrayBuffer | SharedArrayBuffer;
   byteStride?: number;
 }
 
@@ -37,7 +37,6 @@ export function createRemoteBufferView<T extends Thread>(
     },
     {
       name,
-      transferList: [props.buffer],
     }
   );
 
@@ -46,6 +45,6 @@ export function createRemoteBufferView<T extends Thread>(
     thread: props.thread,
     resourceId,
     byteStride,
-    buffer: props.buffer,
+    buffer: props.buffer instanceof SharedArrayBuffer ? props.buffer : undefined,
   };
 }

--- a/src/plugins/thirdroom/thirdroom.game.ts
+++ b/src/plugins/thirdroom/thirdroom.game.ts
@@ -1,4 +1,4 @@
-import { addEntity, defineQuery, removeEntity } from "bitecs";
+import { addEntity, defineQuery } from "bitecs";
 import { vec3 } from "gl-matrix";
 
 import { SpawnPoint } from "../../engine/component/SpawnPoint";
@@ -278,7 +278,7 @@ async function onEnterWorld(state: GameState, message: EnterWorldMessage) {
   const spawnPoints = spawnPointQuery(world);
 
   if (state.activeCamera) {
-    removeEntity(world, state.activeCamera);
+    removeRecursive(world, state.activeCamera);
   }
 
   const characterControllerType = SceneCharacterControllerComponent.get(state.activeScene)?.type;

--- a/src/ui/views/session/SessionView.tsx
+++ b/src/ui/views/session/SessionView.tsx
@@ -264,6 +264,7 @@ export function SessionView() {
 
     if (networkInterfaceRef.current) {
       networkInterfaceRef.current();
+      networkInterfaceRef.current = undefined;
     }
   }, [navigate]);
 

--- a/test/engine/component/transform.test.ts
+++ b/test/engine/component/transform.test.ts
@@ -166,34 +166,33 @@ describe("Transform Unit Tests", function () {
 
       test("should traverse in depth first order", () => {
         /**
-         *       root(1)
-         *         / \
-         *      A(2) B(3)
-         *      /     / \
-         *    E(6)  C(4) D(5)
-         *    /
-         *   F(7)
+         * 1 --> 2 ---> 5
+         *   |-> 3 ---> 6
+         *   |-> 4  |-> 7
+         *          |-> 8
          */
 
-        const root = 1;
-        const childA = 2;
-        const childB = 3;
-        const childC = 4;
-        const childD = 5;
-        const childE = 6;
-        const childF = 7;
-        addChild(root, childA);
-        addChild(root, childB);
-        addChild(childB, childC);
-        addChild(childB, childD);
-        addChild(childA, childE);
-        addChild(childE, childF);
+        const entity1 = 1;
+        const entity2 = 2;
+        const entity3 = 3;
+        const entity4 = 4;
+        const entity5 = 5;
+        const entity6 = 6;
+        const entity7 = 7;
+        const entity8 = 8;
+        addChild(entity1, entity2);
+        addChild(entity1, entity3);
+        addChild(entity1, entity4);
+        addChild(entity2, entity5);
+        addChild(entity3, entity6);
+        addChild(entity3, entity7);
+        addChild(entity3, entity8);
 
         const result: number[] = [];
 
         traverse(1, (eid) => result.push(eid));
 
-        expect(result).toStrictEqual([1, 2, 6, 7, 3, 4, 5]);
+        expect(result).toStrictEqual([1, 2, 5, 3, 6, 7, 8, 4]);
       });
 
       test("should skip children if you return false", () => {
@@ -245,6 +244,58 @@ describe("Transform Unit Tests", function () {
 
         expect(results2).toStrictEqual([1, 2, 6, 7]);
       });
+
+      test("should correctly traverse a sub-tree", () => {
+        /**
+         *       A(1)
+         *         / \
+         *      B(2) C(root 3)
+         *      /     / \
+         *    F(6)  D(4) E(5)
+         *    /
+         *   G(7)
+         */
+
+        const entityA = 1;
+        const entityB = 2;
+        const entityC = 3;
+        const entityD = 4;
+        const entityE = 5;
+        const entityF = 6;
+        const entityG = 7;
+        addChild(entityA, entityB);
+        addChild(entityA, entityC);
+        addChild(entityC, entityD);
+        addChild(entityC, entityE);
+        addChild(entityB, entityF);
+        addChild(entityF, entityG);
+
+        const results: number[] = [];
+
+        traverse(entityC, (eid) => {
+          results.push(eid);
+        });
+
+        expect(results).toStrictEqual([3, 4, 5]);
+      });
+
+      test("should traverse a single entity", () => {
+        const entityA = 1;
+        const entityB = 2;
+        const entityC = 3;
+
+        addChild(entityA, entityB);
+        addChild(entityA, entityC);
+
+        const results: number[] = [];
+
+        traverse(entityB, (eid) => {
+          results.push(eid);
+        });
+
+        expect(results).toStrictEqual([entityB]);
+        console.log("yup");
+      }, 1000);
     });
   });
 


### PR DESCRIPTION
Continuation of https://github.com/matrix-org/thirdroom/pull/105

To Do:
- [ ] Investigate game thread memory usage hovering around 60mb
  - Could just be that the physics world has high overhead on top of our various component stores
- [ ] Total memory usage in the Chrome task manager is quite high while the GPU and JS heap is pretty reasonable. We should know where this is coming from.
- [ ] It looks like we're not disposing of some blobs for various images based on chrome://blob-internals/
  - Is this just room avatars/previews or is it also textures?
- [x] We're spitting out errors for a bunch of rejected promises when we leave a scene. I think we should catch these errors hand handle them silently.
- [x] We still need to handle cleaning up Three.js resources like textures and geometries etc.
- [ ] There is also more work required to clean up audio resources
- [x] `thirdroom.game.ts:258 RangeError: Maximum call stack size exceeded` when reloading UK City scene