### PR TITLE
Replace font from cdn to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "3d-tiles-renderer": "https://github.com/matrix-org/3DTilesRendererJS.git#v0.3.9-patch",
     "@dimforge/rapier3d-compat": "0.7.6",
+    "@fontsource/inter": "^4.5.12",
     "@gltf-transform/core": "^2.3.0",
     "@gltf-transform/extensions": "^2.3.0",
     "@gltf-transform/functions": "^2.3.0",

--- a/src/ui/App.css
+++ b/src/ui/App.css
@@ -1,5 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap");
-
 @import "./style/display.css";
 @import "./style/flex.css";
 @import "./style/text.css";
@@ -173,8 +171,8 @@ body {
   height: 100%;
   background-color: var(--bg-surface);
   color: var(--tc-surface);
-  font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans",
-    "Droid Sans", "Helvetica Neue", sans-serif;
+  font-family: InterVariable, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+    "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-variant-ligatures: no-contextual;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -3,6 +3,7 @@ import { Route, Routes } from "react-router-dom";
 import { useFocusVisible } from "@react-aria/interactions";
 
 import "./App.css";
+import "@fontsource/inter/variable.css";
 
 import { HydrogenRootView } from "./views/HydrogenRootView";
 import { LoginView } from "./views/login/LoginView";

--- a/yarn.lock
+++ b/yarn.lock
@@ -374,6 +374,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@fontsource/inter@^4.5.12":
+  version "4.5.12"
+  resolved "https://registry.yarnpkg.com/@fontsource/inter/-/inter-4.5.12.tgz#a6236379bf710658db048d7087ec588754962cb6"
+  integrity sha512-bGKk4/8tube/nCk8hav0ZDBVbzJzc7m0Vt4xF5p15IN4YImwGdtKG38Oq5bU8xHNS+VfvbFFCepgQNj7Pr/Lvg==
+
 "@gltf-transform/core@^2.3.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@gltf-transform/core/-/core-2.3.0.tgz#0a449822319d7ead2296688095ebba7029a625f6"


### PR DESCRIPTION
Uses https://fontsource.org/fonts/inter package instead of google cdn