### PR TITLE
Fix MeshBasicMaterial

### DIFF
--- a/src/engine/mesh/mesh.render.ts
+++ b/src/engine/mesh/mesh.render.ts
@@ -450,12 +450,14 @@ function createMeshPrimitiveObject(
       material.defines = {};
     }
 
-    material.defines.USE_ENVMAP = "";
-    material.defines.ENVMAP_MODE_REFLECTION = "";
-    material.defines.ENVMAP_TYPE_CUBE_UV = "";
-    material.defines.CUBEUV_2D_SAMPLER_ARRAY = "";
-    material.defines.ENVMAP_BLENDING_NONE = "";
-    material.defines.USE_REFLECTION_PROBES = "";
+    if (!("isMeshBasicMaterial" in material)) {
+      material.defines.USE_ENVMAP = "";
+      material.defines.ENVMAP_MODE_REFLECTION = "";
+      material.defines.ENVMAP_TYPE_CUBE_UV = "";
+      material.defines.CUBEUV_2D_SAMPLER_ARRAY = "";
+      material.defines.ENVMAP_BLENDING_NONE = "";
+      material.defines.USE_REFLECTION_PROBES = "";
+    }
 
     if (instancedMesh) {
       material.defines.USE_INSTANCING = "";


### PR DESCRIPTION
We were forcing environment maps and reflection probes to be turned on for MeshBasicMaterial which doesn't support reflection probes. Now we check to see what material it is before turning them on.