### PR TITLE
Move back to using PNG for RGBM encoded lightmaps

### DIFF
--- a/src/asset-pipeline/functions/compressTextures.ts
+++ b/src/asset-pipeline/functions/compressTextures.ts
@@ -51,15 +51,15 @@ export function compressTextures(): Transform {
 
       const name = texture.getName() || texture.getURI();
       const slots = listTextureSlots(doc, texture);
-      const isSRGB = slots.some(
-        (slotName) => slotName === "baseColorTexture" || slotName === "emissiveTexture" || "lightMapTexture"
-      );
+      const isSRGB = slots.some((slotName) => slotName === "baseColorTexture" || slotName === "emissiveTexture");
       const isNormal = slots.some((slotName) => slotName === "normalTexture");
 
       const workerIndex = jobs.size % workers.length;
       const worker = workers[workerIndex];
 
-      const useOptiPng = texture.listParents().some((prop) => prop.propertyType === "ReflectionProbe");
+      const useOptiPng = texture
+        .listParents()
+        .some((prop) => prop.propertyType === "ReflectionProbe" || prop.propertyType === "Lightmap");
 
       if (useOptiPng && mimeType === "image/jpeg") {
         continue;


### PR DESCRIPTION
Using UASTC for RGBM encoded textures still needs some work in the Basis Encoder. Maybe there's another way to do compressed HDR textures but for now we'll move back to using PNGs

https://community.arm.com/arm-community-blogs/b/graphics-gaming-and-vr-blog/posts/high-quality-rgbm-texture-compression-with-astc