### PR TITLE
Fix Safari

### DIFF
--- a/src/engine/GameTypes.ts
+++ b/src/engine/GameTypes.ts
@@ -4,8 +4,6 @@ import { BaseThreadContext } from "./module/module.common";
 
 export type World = IWorld;
 
-export type RenderPort = MessagePort | (typeof globalThis & Worker);
-
 export interface GameState extends BaseThreadContext {
   mainToGameTripleBufferFlags: Uint8Array;
   gameToMainTripleBufferFlags: Uint8Array;
@@ -15,5 +13,4 @@ export interface GameState extends BaseThreadContext {
   world: World;
   activeScene: number;
   activeCamera: number;
-  renderPort: RenderPort;
 }

--- a/src/engine/module/MockMessageChannel.ts
+++ b/src/engine/module/MockMessageChannel.ts
@@ -1,0 +1,107 @@
+class TransferableMessageEvent<T> extends MessageEvent<T> {
+  public transferList?: any[];
+}
+
+export class MockMessagePort {
+  private started = false;
+  private closed = false;
+  private eventHandlers: Map<string, ((event: any) => void)[]> = new Map();
+  private messageQueue: any[] = [];
+
+  constructor(private messageChannel: MockMessageChannel, private target: string) {}
+
+  addEventListener(event: string, handler: (...args: any[]) => void) {
+    let handlers = this.eventHandlers.get(event);
+
+    if (!handlers) {
+      handlers = [];
+      this.eventHandlers.set(event, handlers);
+    }
+
+    handlers.push(handler);
+  }
+
+  removeEventListener(event: string, handler: (...args: any[]) => void) {
+    const handlers = this.eventHandlers.get(event);
+
+    if (!handlers) {
+      return;
+    }
+
+    const index = handlers.indexOf(handler);
+
+    if (index !== -1) {
+      handlers.splice(index, 1);
+    }
+  }
+
+  postMessage(message: any, transferList?: any[]) {
+    if (this.closed) {
+      return;
+    }
+
+    const event = new TransferableMessageEvent("message", { data: message });
+    event.transferList = transferList;
+
+    if (this.started) {
+      ((this.messageChannel as any)[this.target] as MockMessagePort).dispatchEvent(event);
+    } else {
+      this.messageQueue.push(event);
+    }
+  }
+
+  dispatchEvent(event: any) {
+    const eventHandlers = this.eventHandlers.get(event.type);
+
+    if (eventHandlers) {
+      for (let i = 0; i < eventHandlers.length; i++) {
+        eventHandlers[i](event);
+      }
+    }
+  }
+
+  start() {
+    this.started = true;
+
+    while (this.messageQueue.length) {
+      const event = this.messageQueue.pop();
+
+      if (!event) {
+        break;
+      }
+
+      ((this.messageChannel as any)[this.target] as MockMessagePort).dispatchEvent(event);
+    }
+  }
+
+  close() {
+    this.closed = true;
+    this.messageQueue.length = 0;
+  }
+}
+
+export class MockMessageChannel {
+  port1: MockMessagePort;
+  port2: MockMessagePort;
+
+  constructor() {
+    this.port1 = new MockMessagePort(this, "port2");
+    this.port2 = new MockMessagePort(this, "port1");
+  }
+}
+
+export class MockWorkerMessageChannel extends MockMessageChannel {
+  constructor(worker: Worker) {
+    super();
+
+    worker.addEventListener("message", (event) => {
+      this.port2.postMessage(event.data);
+    });
+
+    this.port2.addEventListener("message", (event) => {
+      worker.postMessage(event.data, event.transferList);
+    });
+
+    this.port2.start();
+  }
+}

--- a/src/engine/network/network.game.ts
+++ b/src/engine/network/network.game.ts
@@ -28,7 +28,7 @@ import { addChild, removeRecursive, skipRenderLerp, Transform } from "../compone
 import { GameState } from "../GameTypes";
 import { NOOP } from "../config.common";
 import { Player } from "../component/Player";
-import { defineModule, getModule, registerMessageHandler } from "../module/module.common";
+import { defineModule, getModule, registerMessageHandler, Thread } from "../module/module.common";
 import {
   AddPeerIdMessage,
   NetworkMessage,
@@ -50,9 +50,6 @@ import { RigidBody } from "../physics/physics.game";
 import { deserializeRemoveOwnership } from "./ownership.game";
 import { createRemoteNametag } from "../nametag/nametag.game";
 import { createHistorian, Historian } from "./Historian";
-
-// type hack for postMessage(data, transfers) signature in worker
-const worker: Worker = self as any;
 
 /*********
  * Types *
@@ -848,7 +845,8 @@ export const broadcastReliable = (state: GameState, packet: ArrayBuffer) => {
   // state.network.peers.forEach((peerId: string) => {
   //   sendReliable(state, peerId, packet);
   // });
-  worker.postMessage(
+  state.sendMessage(
+    Thread.Main,
     {
       type: NetworkMessageType.NetworkBroadcast,
       packet,
@@ -860,9 +858,10 @@ export const broadcastReliable = (state: GameState, packet: ArrayBuffer) => {
 
 export const broadcastUnreliable = (state: GameState, packet: ArrayBuffer) => {
   // state.network.peers.forEach((peerId: string) => {
-  //   sendUnreliable(peerId, packet);
+  //   sendUnreliable(state, peerId, packet);
   // });
-  worker.postMessage(
+  state.sendMessage(
+    Thread.Main,
     {
       type: NetworkMessageType.NetworkBroadcast,
       packet,
@@ -875,7 +874,8 @@ export const broadcastUnreliable = (state: GameState, packet: ArrayBuffer) => {
 export const sendReliable = (state: GameState, peerId: string, packet: ArrayBuffer) => {
   // todo: headers
   // packet = writeHeaders(state, peerId, packet);
-  worker.postMessage(
+  state.sendMessage(
+    Thread.Main,
     {
       type: NetworkMessageType.NetworkMessage,
       peerId,
@@ -886,8 +886,9 @@ export const sendReliable = (state: GameState, peerId: string, packet: ArrayBuff
   );
 };
 
-export const sendUnreliable = (peerId: string, packet: ArrayBuffer) => {
-  worker.postMessage(
+export const sendUnreliable = (state: GameState, peerId: string, packet: ArrayBuffer) => {
+  state.sendMessage(
+    Thread.Main,
     {
       type: NetworkMessageType.NetworkMessage,
       peerId,

--- a/src/engine/renderer/renderer.main.ts
+++ b/src/engine/renderer/renderer.main.ts
@@ -26,7 +26,12 @@ export const RendererModule = defineModule<IMainThreadContext, MainRendererModul
     return {};
   },
   init(ctx) {
-    ctx.gameWorker.postMessage({
+    ctx.sendMessage(Thread.Render, {
+      type: WorkerMessageType.RenderWorkerResize,
+      canvasWidth: ctx.canvas.clientWidth,
+      canvasHeight: ctx.canvas.clientHeight,
+    });
+    ctx.sendMessage(Thread.Game, {
       type: WorkerMessageType.RenderWorkerResize,
       canvasWidth: ctx.canvas.clientWidth,
       canvasHeight: ctx.canvas.clientHeight,
@@ -40,12 +45,12 @@ export const RendererModule = defineModule<IMainThreadContext, MainRendererModul
 
 const registerResizeEventHandler = (ctx: IMainThreadContext) => {
   function onResize() {
-    ctx.renderWorker.postMessage({
+    ctx.sendMessage(Thread.Render, {
       type: WorkerMessageType.RenderWorkerResize,
       canvasWidth: ctx.canvas.clientWidth,
       canvasHeight: ctx.canvas.clientHeight,
     });
-    ctx.gameWorker.postMessage({
+    ctx.sendMessage(Thread.Game, {
       type: WorkerMessageType.RenderWorkerResize,
       canvasWidth: ctx.canvas.clientWidth,
       canvasHeight: ctx.canvas.clientHeight,

--- a/src/engine/renderer/renderer.render.ts
+++ b/src/engine/renderer/renderer.render.ts
@@ -46,7 +46,7 @@ import {
   updateLocalTextureResources,
 } from "../texture/texture.render";
 import { createDisposables } from "../utils/createDisposables";
-import { PostMessageTarget, RenderWorkerResizeMessage, WorkerMessageType } from "../WorkerMessage";
+import { RenderWorkerResizeMessage, WorkerMessageType } from "../WorkerMessage";
 import {
   InitializeCanvasMessage,
   InitializeRendererTripleBuffersMessage,
@@ -92,7 +92,6 @@ export interface RenderThreadState extends BaseThreadContext {
   canvas?: HTMLCanvasElement;
   elapsed: number;
   dt: number;
-  gameWorkerMessageTarget: PostMessageTarget;
   gameToRenderTripleBufferFlags: Uint8Array;
 }
 


### PR DESCRIPTION
This PR fixes loading Third Room in Safari by using a mocked MessageChannel interface to post messages between workers and when both the MainThread and RenderWorker are ran on the MainThread. Safari cannot properly `postMessage` `SharedArrayBuffer` objects over `MessageChannel` and this works around that bug.