### PR TITLE
nametag overlay bugfix

### DIFF
--- a/src/ui/views/session/nametags/Nametags.tsx
+++ b/src/ui/views/session/nametags/Nametags.tsx
@@ -115,17 +115,14 @@ function Nametag({ room, nametag, groupCall }: NametagProps) {
   );
 }
 
-export function Nametags({ room, enabled }: { room: Room; enabled: boolean }) {
+export function Nametags({ room, show }: { room: Room; show: boolean }) {
   const engine = useMainThreadContext();
 
   const [nametags, setNametags] = useState<LocalNametag[]>([]);
 
-  const onNametagsChanged = useCallback(
-    (nametags: LocalNametag[]) => {
-      setNametags([...nametags]);
-    },
-    [setNametags]
-  );
+  const onNametagsChanged = useCallback((nametags: LocalNametag[]) => {
+    setNametags([...nametags]);
+  }, []);
 
   useEffect(() => {
     const audioModule = getModule(engine, AudioModule);
@@ -152,7 +149,7 @@ export function Nametags({ room, enabled }: { room: Room; enabled: boolean }) {
 
   return (
     <div>
-      {enabled &&
+      {show &&
         nametags.map((nametag) => (
           <Nametag key={nametag.resourceId} room={room} nametag={nametag} groupCall={groupCall as GroupCall} />
         ))}

--- a/src/ui/views/session/world/WorldView.tsx
+++ b/src/ui/views/session/world/WorldView.tsx
@@ -105,6 +105,7 @@ export function WorldView() {
       if (isEscape && isOverlayOpen) {
         canvasRef.current?.requestPointerLock();
         closeOverlay();
+        setShowFocusedEntity(showFocusedEntity);
         return;
       }
       if (isEscape && isOverlayOpen === false) {
@@ -144,6 +145,7 @@ export function WorldView() {
       isChatOpen,
       isOverlayOpen,
       showFocusedEntity,
+      setShowFocusedEntity,
       showActiveMembers,
       openWorldChat,
       closeWorldChat,
@@ -224,7 +226,7 @@ export function WorldView() {
       </div>
       {world && renderControl()}
       {world && editorEnabled && <EditorView />}
-      {!("isBeingCreated" in world) && !isOverlayOpen && <Nametags room={world} enabled={showFocusedEntity} />}
+      {!("isBeingCreated" in world) && <Nametags room={world} show={showFocusedEntity && !isOverlayOpen} />}
       {!("isBeingCreated" in world) && (
         <Dialog open={showActiveMembers} onOpenChange={setShowActiveMembers}>
           <MemberListDialog room={world} requestClose={() => setShowActiveMembers(false)} />

--- a/src/ui/views/session/world/WorldView.tsx
+++ b/src/ui/views/session/world/WorldView.tsx
@@ -160,7 +160,6 @@ export function WorldView() {
       if (isEscape && isOverlayOpen) {
         canvasRef.current?.requestPointerLock();
         closeOverlay();
-        setShowFocusedEntity(showFocusedEntity);
         return;
       }
       if (isEscape && isOverlayOpen === false) {


### PR DESCRIPTION
fixes nametags permanently disappearing when overlay is opened, as well as a few other edge cases

Fixes #228 