### PR TITLE
Add CORS header for Sentry

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -22,6 +22,7 @@ for = "/*"
   [headers.values]
     Cross-Origin-Opener-Policy = "same-origin"
     Cross-Origin-Embedder-Policy = "require-corp"
+    Access-Control-Allow-Origin = "sentry.tools.element.io"
 
 [[headers]]
 for = "/.well-known/*"


### PR DESCRIPTION
This may address CORS concerns for calls to sentry.tools.element.io