### PR TITLE
Fix reflections being the wrong way around

### DIFF
--- a/src/engine/gltf/MX_reflection_probes.ts
+++ b/src/engine/gltf/MX_reflection_probes.ts
@@ -48,7 +48,7 @@ async function _loadGLTFReflectionProbe(
   const reflectionProbe = createReflectionProbeResource(ctx, {
     reflectionProbeTexture: await loadGLTFTexture(ctx, resource, reflectionProbeDef.reflectionProbeTexture.index, {
       mapping: SamplerMapping.EquirectangularReflectionMapping,
-      flipY: true,
+      flipY: false,
     }),
     size: reflectionProbeDef.size ? new Float32Array(reflectionProbeDef.size) : undefined,
   });

--- a/src/engine/material/patchShaderChunks.ts
+++ b/src/engine/material/patchShaderChunks.ts
@@ -138,6 +138,7 @@ export default function patchShaderChunks() {
   ShaderChunk.envmap_physical_pars_fragment = ShaderChunk.envmap_physical_pars_fragment.replace(
     "vec4 envMapColor = textureCubeUV( envMap, reflectVec, roughness );",
     `
+    reflectVec = -reflectVec;
     #ifdef USE_REFLECTION_PROBES
       #ifdef USE_INSTANCING
         vec4 envMapColor = mix(


### PR DESCRIPTION
I don't know what I'm doing, but this appears to do a thing.

![image](https://user-images.githubusercontent.com/1190097/191891793-ae9dbce1-8537-4fa3-a465-1747e5cc3dbd.png)

It's also not perfect, but it's at least reflecting the environment back rather than acting as a spherical window.