### PR TITLE
Migrate m.world -> org.matrix.msc3815.world

### DIFF
--- a/res/defaultWorlds.json
+++ b/res/defaultWorlds.json
@@ -1,6 +1,6 @@
 {
   "home": {
-    "version": 3,
+    "version": 4,
     "sceneUrl": "mxc://thirdroom.io/VPsSUQAxjzRZMpAiAeWDfbQX",
     "scenePreviewUrl": "mxc://thirdroom.io/OvtWlQFZzTTvEMoQbYnNtVec",
     "defaultAvatar": {

--- a/src/ui/hooks/useHomeWorld.ts
+++ b/src/ui/hooks/useHomeWorld.ts
@@ -39,7 +39,7 @@ async function createHomeWorld(session: Session) {
     },
     initialState: [
       {
-        type: "m.world",
+        type: "org.matrix.msc3815.world",
         content: {
           version: defaultWorlds.home.version,
           scene_url: defaultWorlds.home.sceneUrl,
@@ -64,7 +64,7 @@ async function updateHomeWorld(session: Session, accountData: HomeWorldAccountDa
   }
 
   await session.hsApi
-    .sendState(room.id, "m.world", "", {
+    .sendState(room.id, "org.matrix.msc3815.world", "", {
       scene_url: defaultWorlds.home.sceneUrl,
       scene_preview_url: defaultWorlds.home.scenePreviewUrl,
     })
@@ -79,8 +79,8 @@ export function useHomeWorld() {
     async function run() {
       const homeAccountData = await session.getAccountData("org.matrix.msc3815.world.home");
 
-      if (homeAccountData) {
-        if (!homeAccountData.version || homeAccountData.version < defaultWorlds.home.version) {
+      if (homeAccountData && homeAccountData.version && homeAccountData.version >= 4) {
+        if (homeAccountData.version < defaultWorlds.home.version) {
           await updateHomeWorld(session, homeAccountData);
 
           await session.setAccountData("org.matrix.msc3815.world.home", {
@@ -91,6 +91,10 @@ export function useHomeWorld() {
 
         setHomeWorldId(homeAccountData.room_id);
       } else {
+        if (homeAccountData && homeAccountData.version && homeAccountData.version <= 3) {
+          await session.rooms.get(homeAccountData.room_id)?.leave();
+        }
+
         const roomBeingCreated = await createHomeWorld(session);
 
         setHomeWorldId(roomBeingCreated.id);

--- a/src/ui/views/session/SessionView.tsx
+++ b/src/ui/views/session/SessionView.tsx
@@ -109,7 +109,7 @@ export default function SessionView() {
     state.world.loadingWorld(world.id);
 
     world
-      .observeStateTypeAndKey("m.world", "")
+      .observeStateTypeAndKey("org.matrix.msc3815.world", "")
       .then((observable) => {
         const onLoad = async (event: StateEvent | undefined) => {
           let sceneUrl = event?.content?.scene_url;
@@ -153,6 +153,17 @@ export default function SessionView() {
 
         if (initialEvent) {
           onLoad(initialEvent);
+        } else {
+          world
+            .getStateEvent("m.world")
+            .then((result) => {
+              if (result) {
+                const error = new Error("World needs to be manually updated by owner.");
+                console.error(error);
+                state.world.setWorldError(error as Error);
+              }
+            })
+            .catch(console.error);
         }
       })
       .catch((error) => {

--- a/src/ui/views/session/create-world/CreateWorld.tsx
+++ b/src/ui/views/session/create-world/CreateWorld.tsx
@@ -97,7 +97,7 @@ export function CreateWorld() {
           kick: 100,
           ban: 100,
           redact: 50,
-          state_default: 0,
+          state_default: 50,
           events_default: 0,
           users_default: 0,
           events: {
@@ -109,6 +109,7 @@ export function CreateWorld() {
             "m.room.message": 0,
             "m.room.encrypted": 50,
             "m.sticker": 50,
+            "org.matrix.msc3815.world": 50,
             "org.matrix.msc3401.call.member": 0,
             "org.matrix.msc3815.member.world": 0,
           },
@@ -118,7 +119,7 @@ export function CreateWorld() {
         },
         initialState: [
           {
-            type: "m.world",
+            type: "org.matrix.msc3815.world",
             content: {
               scene_url: sceneMxc,
               scene_preview_url: scenePrevMxc,

--- a/src/ui/views/session/overlay/Overlay.tsx
+++ b/src/ui/views/session/overlay/Overlay.tsx
@@ -98,7 +98,7 @@ export function Overlay({
         return;
       }
 
-      world.getStateEvent("m.world").then((result: any) => {
+      world.getStateEvent("org.matrix.msc3815.world").then((result: any) => {
         const scenePreviewUrl = result?.event?.content?.scene_preview_url as string | unknown;
         let scenePreviewThumbnail = scenePreviewUrl;
 


### PR DESCRIPTION
This PR ensures we're using the right namespaced world state event. You'll need to go into the world settings, make a modification, hit save to update the world. Or create a new one if you're not interested in it anymore. Homeworlds should migrate automatically.