### PR TITLE
Improve transferring between worlds

### DIFF
--- a/src/ui/views/session/SessionView.tsx
+++ b/src/ui/views/session/SessionView.tsx
@@ -319,13 +319,16 @@ export default function SessionView() {
     async (uri: string) => {
       const state = useStore.getState();
 
-      // exit current world
-      onExitWorld();
-
       const parsedUri = parseMatrixUri(uri);
 
       if (parsedUri instanceof URL) {
         return;
+      }
+
+      // Terminate previous world's network connection
+      if (networkInterfaceRef.current) {
+        networkInterfaceRef.current();
+        networkInterfaceRef.current = undefined;
       }
 
       // select new world
@@ -352,7 +355,7 @@ export default function SessionView() {
         clearInterval(interval);
       };
     },
-    [onExitWorld, onLoadSelectedWorld, onJoinSelectedWorld, session]
+    [onLoadSelectedWorld, onJoinSelectedWorld, session]
   );
 
   const outletContext = useMemo<SessionOutletContext>(


### PR DESCRIPTION
There shouldn't be any need to navigate back to the home route when transferring worlds. We can just terminate the last network connection and load up the new world. Everything else should be handled automatically. This prevents thrashing the UI more than we have to and rapidly loading and disposing of the home world.