### PR TITLE
Increase timeout for module dependencies

### DIFF
--- a/src/engine/resource/resource.common.ts
+++ b/src/engine/resource/resource.common.ts
@@ -194,7 +194,7 @@ export const createLocalResourceModule = <ThreadContext extends BaseThreadContex
     let deferred = resourceModule.deferredResources.get(resourceId);
 
     if (!deferred) {
-      deferred = createDeferred<unknown>(3000, `Loading resource ${resourceId} ${description} timed out.`);
+      deferred = createDeferred<unknown>(30000, `Loading resource ${resourceId} ${description} timed out.`);
       resourceModule.deferredResources.set(resourceId, deferred);
     }
 


### PR DESCRIPTION
This should hopefully resolve issues where module dependencies timeout because they take longer than 3 seconds to load. This bumps the timeout to 30 seconds.