### PR TITLE
Fix joining via url

### DIFF
--- a/src/ui/views/session/SessionView.tsx
+++ b/src/ui/views/session/SessionView.tsx
@@ -10,17 +10,20 @@ import { StatusBar } from "./statusbar/StatusBar";
 import { useStore } from "../../hooks/useStore";
 import { LoadingScreen } from "../components/loading-screen/LoadingScreen";
 import { useHomeWorld } from "../../hooks/useHomeWorld";
+import { useUnknownWorldPath } from "../../hooks/useWorld";
 
 export default function SessionView() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const mainThread = useInitMainThreadContext(canvasRef);
   const isOverlayOpen = useStore((state) => state.overlay.isOpen);
+  const [worldId, worldAlias] = useUnknownWorldPath();
   const homeWorldId = useHomeWorld();
+
   useEffect(() => {
-    if (homeWorldId) {
+    if (!worldId && !worldAlias && homeWorldId) {
       useStore.getState().overlayWorld.selectWorld(homeWorldId);
     }
-  }, [homeWorldId]);
+  }, [worldId, worldAlias, homeWorldId]);
 
   return (
     <DndProvider backend={HTML5Backend}>

--- a/src/ui/views/session/overlay/WorldPreview.tsx
+++ b/src/ui/views/session/overlay/WorldPreview.tsx
@@ -78,6 +78,7 @@ function JoinWorldCard({ worldIdOrAlias }: { worldIdOrAlias: string }) {
       desc={error && error.message}
       options={(() => {
         if (loading) {
+          // TODO: this doesn't work because the parent component's state changes when joining
           return (
             <Button variant="secondary" disabled>
               Joining...
@@ -214,7 +215,8 @@ export function WorldPreview() {
           );
         }
 
-        return <WorldPreviewCard title="Unknown error occurred" />;
+        // TODO: this default case may not only be the loading state
+        return <WorldPreviewCard title="Joining World..." />;
       })()}
     </div>
   );


### PR DESCRIPTION
Fixes #401 

Note that this doesn't completely fix the `JoinWorldCard` component. The local loading state never results in the `Joining...` message being shown because the parent component changes.

It works alright for now, but I left some TODOs because the fallback `Joining Room...` state might be invalid in certain cases.