### PR TITLE
Allow for portals to any uri

### DIFF
--- a/src/ui/views/session/world/WorldView.tsx
+++ b/src/ui/views/session/world/WorldView.tsx
@@ -207,6 +207,7 @@ export function WorldView({ world }: WorldViewProps) {
             console.log(message.uri);
             const parsedUri = parseMatrixUri(message.uri);
             if (parsedUri instanceof URL) {
+              window.location.href = parsedUri.href;
               return;
             }
 


### PR DESCRIPTION
If a portal points at a uri that isn't a `matrix:` uri it'll navigate to that page.