### PR TITLE
Fix reading OMI_collider height in glTF-transform

### DIFF
--- a/src/asset-pipeline/extensions/OMIColliderExtension.ts
+++ b/src/asset-pipeline/extensions/OMIColliderExtension.ts
@@ -51,7 +51,7 @@ export class OMIColliderExtension extends Extension {
 
       if (colliderDef.extents !== undefined) collider.setExtents(colliderDef.extents);
       if (colliderDef.radius !== undefined) collider.setRadius(colliderDef.radius);
-      if (colliderDef.height !== undefined) collider.setRadius(colliderDef.height);
+      if (colliderDef.height !== undefined) collider.setHeight(colliderDef.height);
       if (colliderDef.mesh !== undefined) collider.setMesh(context.meshes[colliderDef.mesh!]);
 
       return collider;


### PR DESCRIPTION
Found a small bug when writing up the latest OMI_collider spec. Should fix some collisions in some scenes