### PR TITLE
Fix presentation example

### DIFF
--- a/examples/presentation/js/presentation-example.js
+++ b/examples/presentation/js/presentation-example.js
@@ -9,7 +9,7 @@ let currentSlide = 0;
 const slides = [];
 
 for (let i = 0; i < 7; i++) {
-  slides.push(WebSG.getTextureByName(`Slide${i + 1}`));
+  slides.push(WebSG.getMaterialByName(`Slide${i + 1}`).baseColorTexture);
 }
 
 onupdate = (dt) => {


### PR DESCRIPTION
Use getMaterialByName to fetch texture instead of getTextureByName since the optimizer strips texture names when compressing textures.