### PR TITLE
Fix flipY for compressed textures and other graphics bugs

### DIFF
--- a/src/asset-pipeline/functions/TextureCompressionWorker.ts
+++ b/src/asset-pipeline/functions/TextureCompressionWorker.ts
@@ -36,6 +36,7 @@ interface Job {
   size: vec2;
   isSRGB: boolean;
   isNormal: boolean;
+  flipY: boolean;
   useOptiPng: boolean;
   data: Uint8Array | Uint8ClampedArray;
   mimeType: string;
@@ -58,7 +59,7 @@ async function processJob() {
 
   processingJob = true;
 
-  const { jobId, name, slots, size, useOptiPng, isSRGB, isNormal, data, mimeType } = job;
+  const { jobId, name, slots, size, useOptiPng, isSRGB, isNormal, flipY, data, mimeType } = job;
 
   console.log(
     `Compressing texture "${name}" with ${useOptiPng ? "OptiPNG" : isSRGB ? "ETC1S" : "UASTC"} compression.
@@ -97,6 +98,7 @@ async function processJob() {
     basisEncoder.setCreateKTX2File(true);
     basisEncoder.setKTX2UASTCSupercompression(true);
     basisEncoder.setKTX2SRGBTransferFunc(isSRGB);
+    basisEncoder.setYFlip(flipY);
 
     if (isSRGB) {
       basisEncoder.setUASTC(false);

--- a/src/asset-pipeline/functions/compressTextures.ts
+++ b/src/asset-pipeline/functions/compressTextures.ts
@@ -76,6 +76,7 @@ export function compressTextures(onProgress?: GLTFTransformProgressCallback): Tr
       const slots = listTextureSlots(doc, texture);
       const isSRGB = slots.some((slotName) => slotName === "baseColorTexture" || slotName === "emissiveTexture");
       const isNormal = slots.some((slotName) => slotName === "normalTexture");
+      const flipY = slots.some((slotName) => slotName === "backgroundTexture");
 
       const workerIndex = jobs.size % workers.length;
       const worker = workers[workerIndex];
@@ -123,6 +124,7 @@ export function compressTextures(onProgress?: GLTFTransformProgressCallback): Tr
           size,
           data: imageData,
           mimeType,
+          flipY,
         },
         [imageData.buffer]
       );

--- a/src/engine/material/patchShaderChunks.ts
+++ b/src/engine/material/patchShaderChunks.ts
@@ -155,6 +155,8 @@ export default function patchShaderChunks() {
     #else
       vec4 envMapColor = textureCubeUV( envMap, reflectVec, roughness );
     #endif
+
+    envMapColor = max(envMapColor, 0.0);
     `
   );
 }

--- a/src/engine/reflection-probe/reflection-probe.render.ts
+++ b/src/engine/reflection-probe/reflection-probe.render.ts
@@ -204,6 +204,7 @@ export function updateNodeReflections(ctx: RenderThreadState, scene: RenderScene
           // computeBoundingBox will set geometry.boundingBox
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           boundingBox.copy(primitive.geometry.boundingBox!);
+          boundingBox.expandByScalar(0.01);
 
           // Apply the instance's transform to the bounding box
           boundingBox.applyMatrix4(instanceWorldMatrix);
@@ -223,6 +224,7 @@ export function updateNodeReflections(ctx: RenderThreadState, scene: RenderScene
         instanceReflectionProbeParamsAttribute.needsUpdate = true;
       } else {
         boundingBox.setFromObject(primitive);
+        boundingBox.expandByScalar(0.01);
         const reflectionProbeParams = primitive.userData.reflectionProbeParams as Vector3;
         setReflectionProbeParams(boundingBox, scene, reflectionProbes, reflectionProbeParams);
       }


### PR DESCRIPTION
- Fixed flipY for compressed background textures
- Prevented NaN propagation when envmaps contain negative Infinity / NaN values (need to look further into why this might be happening)
- Prevent zero volume bounding boxes for things like planes which makes reflection probes more accurate