### PR TITLE
Fix upload progress by switching from useDebounce to useThrottle

### DIFF
--- a/src/ui/hooks/useThrottle.ts
+++ b/src/ui/hooks/useThrottle.ts
@@ -1,0 +1,34 @@
+import { useCallback, useRef, useEffect } from "react";
+
+export function useThrottle<T extends any[]>(callback: (...args: T) => void, interval = 100): (...args: T) => void {
+  const timeoutIdRef = useRef<number | undefined>();
+  const lastCalled = useRef<number>(0);
+
+  const throttledCallback = useCallback(
+    (...cbArgs: T) => {
+      const now = Date.now();
+
+      if (now >= lastCalled.current + interval) {
+        callback(...cbArgs);
+      } else {
+        clearTimeout(timeoutIdRef.current);
+
+        timeoutIdRef.current = window.setTimeout(() => {
+          lastCalled.current = now;
+          callback(...cbArgs);
+        });
+      }
+
+      lastCalled.current = now;
+    },
+    [callback, interval]
+  );
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(timeoutIdRef.current);
+    };
+  }, []);
+
+  return throttledCallback;
+}

--- a/src/ui/utils/matrixUtils.ts
+++ b/src/ui/utils/matrixUtils.ts
@@ -128,7 +128,6 @@ export async function uploadAttachment(
 ): Promise<string> {
   const uploadRequest = await hsApi.uploadAttachment(blob, blob.nativeBlob.name, {
     uploadProgress: (sentBytes) => {
-      console.log(sentBytes, blob.size);
       onProgress?.(sentBytes, blob.size);
     },
   });

--- a/src/ui/views/components/AutoFileUpload.tsx
+++ b/src/ui/views/components/AutoFileUpload.tsx
@@ -3,9 +3,9 @@ import { IBlobHandle } from "@thirdroom/hydrogen-view-sdk";
 
 import { FileUploadCard, FileUploadErrorCard } from "./file-upload-card/FileUploadCard";
 import { useAttachmentUpload } from "../../hooks/useAttachmentUpload";
-import { useDebounce } from "../../hooks/useDebounce";
 import { useHydrogen } from "../../hooks/useHydrogen";
 import { useFilePicker } from "../../hooks/useFilePicker";
+import { useThrottle } from "../../hooks/useThrottle";
 
 export interface AutoUploadInfo {
   mxc?: string;
@@ -24,10 +24,8 @@ export function AutoFileUpload({ renderButton, mimeType, onUploadInfo }: AutoFil
 
   const { fileData, pickFile, dropFile } = useFilePicker(platform, mimeType);
   const [progress, setProgress] = useState(0);
-  const { mxc, error, upload, cancel } = useAttachmentUpload(
-    session.hsApi,
-    useDebounce(setProgress, { wait: 200, immediate: true })
-  );
+  const throttledSetProgress = useThrottle(setProgress, 16);
+  const { mxc, error, upload, cancel } = useAttachmentUpload(session.hsApi, throttledSetProgress);
   useEffect(() => {
     if (fileData.blob) upload(fileData.blob);
     else {


### PR DESCRIPTION
The upload bar sometimes would get stuck and not update until after an upload had finished. This is because the upload box was using a debounced setState function instead of a throttled function.