### PR TITLE
Re-enable isStatic for environment

### DIFF
--- a/src/plugins/thirdroom/thirdroom.game.ts
+++ b/src/plugins/thirdroom/thirdroom.game.ts
@@ -563,7 +563,7 @@ async function loadEnvironment(ctx: GameState, url: string, scriptUrl?: string, 
 
   if (ctx.worldResource.environment) {
     traverse(ctx.worldResource.environment.publicScene, (node) => {
-      node.isStatic = false;
+      node.isStatic = true;
     });
   }
 


### PR DESCRIPTION
Looks like we forgot to flip this back on after working on the editor. Oops! This should fix the recent performance regression.