### PR TITLE
Don't wait for avatar model to load in module initialization

### DIFF
--- a/src/plugins/thirdroom/thirdroom.game.ts
+++ b/src/plugins/thirdroom/thirdroom.game.ts
@@ -226,7 +226,9 @@ export const ThirdRoomModule = defineModule<GameState, ThirdRoomModuleState>({
       registerMessageHandler(ctx, ThirdRoomMessageType.FindResourceRetainers, onFindResourceRetainers),
     ];
 
-    await loadGLTF(ctx, "/gltf/full-animation-rig.glb");
+    loadGLTF(ctx, "/gltf/full-animation-rig.glb").catch((error) => {
+      console.error("Error loading avatar:", error);
+    });
 
     registerPrefab(ctx, {
       name: "avatar",


### PR DESCRIPTION
Speeds up engine initialization times and decreases the likelihood that we time out during loading modules.