### PR TITLE
Error display fix & escape hatch

### DIFF
--- a/src/ui/views/session/world/MainMenuRootView.tsx
+++ b/src/ui/views/session/world/MainMenuRootView.tsx
@@ -27,7 +27,7 @@ export default function MainMenuRootView() {
     if (entered) {
       exitWorld();
     }
-  }, [loading, entered, exitWorld]);
+  }, [entered, exitWorld]);
 
   return (
     <>

--- a/src/ui/views/session/world/WorldLoading.tsx
+++ b/src/ui/views/session/world/WorldLoading.tsx
@@ -44,7 +44,7 @@ export function WorldLoading({ world, loading, error }: { world: Room; loading: 
   const [resetLoadProgress, loadProgress] = useWorldLoadingProgress();
   const [creator, setCreator] = useState<string>();
   const { session } = useHydrogen(true);
-  const { navigateEnterWorld } = useWorldNavigator(session);
+  const { navigateEnterWorld, navigateExitWorld } = useWorldNavigator(session);
 
   useEffect(() => {
     resetLoadProgress();
@@ -73,13 +73,22 @@ export function WorldLoading({ world, loading, error }: { world: Room; loading: 
             title={world.name ?? world.canonicalAlias ?? "Unknown World"}
             desc={error.message}
             options={
-              <Button
-                onClick={() => {
-                  navigateEnterWorld(world, { reload: true });
-                }}
-              >
-                Reload
-              </Button>
+              <>
+                <Button
+                  onClick={() => {
+                    navigateEnterWorld(world, { reload: true });
+                  }}
+                >
+                  Reload
+                </Button>
+                <Button
+                  onClick={() => {
+                    navigateExitWorld();
+                  }}
+                >
+                  Exit
+                </Button>
+              </>
             }
           />
         </div>

--- a/src/ui/views/session/world/WorldLoading.tsx
+++ b/src/ui/views/session/world/WorldLoading.tsx
@@ -71,7 +71,7 @@ export function WorldLoading({ world, loading, error }: { world: Room; loading: 
         <div className="WorldLoading flex justify-center">
           <WorldPreviewCard
             title={world.name ?? world.canonicalAlias ?? "Unknown World"}
-            // desc={error.message}
+            desc={error.message}
             options={
               <Button
                 onClick={() => {


### PR DESCRIPTION
if anything goes permanently wrong with the room state for some reason (like uploading an invalid file somehow), there was no way to get out of the error state except refreshing. this adds an exit button and fixes the error display