### PR TITLE
Add sliding-sync information to .well-known/matrix/client

### DIFF
--- a/public/well-known/matrix/client
+++ b/public/well-known/matrix/client
@@ -6,4 +6,7 @@
     "issuer": "https://id.thirdroom.io/realms/thirdroom",
     "account": "https://id.thirdroom.io/realms/thirdroom/account"
   }
+  "org.matrix.msc3575.proxy": {
+    "url": "https://sync.matrix.thirdroom.io/"
+  }
 }


### PR DESCRIPTION
The sliding-sync instance is up but our well-known delegations must be handled in the static site since `thirdroom.io` points to Netlify

Internal issue: https://github.com/vector-im/sre-internal/issues/2394