### PR TITLE
Add vim mode to script editor

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,8 @@
+// monaco-vim does not have types, so we create a shallow module definition for our purposes
+declare module "monaco-vim" {
+  interface VimMode {
+    dispose();
+  }
+
+  function initVimMode(editor: MonacoEditor.IStandaloneCodeEditor, statusBar: HTMLElement | null): VimMode;
+}

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "meshoptimizer": "^0.18.1",
     "monaco-editor": "^0.36.1",
     "monaco-themes": "^0.4.3",
+    "monaco-vim": "^0.4.0",
     "murmurhash-js": "^1.0.0",
     "optipng-js": "^0.1.2",
     "react": "^17.0.2",

--- a/src/ui/views/session/cmd-panel/actions.tsx
+++ b/src/ui/views/session/cmd-panel/actions.tsx
@@ -21,9 +21,10 @@ import CrossIC from "../../../../../res/ic/cross.svg";
 import { togglePhysicsDebug } from "../../../../plugins/thirdroom/thirdroom.main";
 import { useDisableInput } from "../../../hooks/useDisableInput";
 
-enum ActionSection {
+export enum ActionSection {
   Global = "Global",
   World = "World",
+  Editor = "Editor",
 }
 
 export const useUserProfileAction = () => {
@@ -236,7 +237,7 @@ export const useToggleEditorAction = (
         name: "Toggle Editor",
         shortcut: ["`"],
         keywords: "editor",
-        section: ActionSection.World,
+        section: ActionSection.Editor,
         icon: undefined,
         subtitle: undefined,
         perform: () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
   "include": [
     "./src",
     "./deps.d.ts",
+    "./index.d.ts",
     "./test",
     "./vite.config.ts",
     "./logviewer/src",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5164,6 +5164,11 @@ monaco-themes@^0.4.3:
   dependencies:
     fast-plist "^0.1.2"
 
+monaco-vim@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/monaco-vim/-/monaco-vim-0.4.0.tgz#060b89bd00f3731ca48586a06023954fd5beaaf2"
+  integrity sha512-+CsW0+Mvx2+eitkXS7OpUXIu57qXlqAL8oVkYhkPCEZ/c6+6gOp/IcG7w+Lb33YiZuTyvJ891+czkeJRPIEwVA==
+
 mrmime@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz"


### PR DESCRIPTION
This PR:
- Adds a dependency on `monaco-vim`.
- Integrates `monaco-vim` into the `ScriptEditor` UI component.
- Adds a kbar action to toggle vim mode, available when the ScriptEditor component is mounted.