### PR TITLE
Physics body handle mapping bugfix

### DIFF
--- a/src/engine/physics/physics.game.ts
+++ b/src/engine/physics/physics.game.ts
@@ -329,8 +329,6 @@ export function addPhysicsBody(
 
   node.physicsBody.body = body;
 
-  handleToEid.set(body.handle, node.eid);
-
   if (node.collider) {
     const colliderDescriptions = createNodeColliderDescriptions(node);
 

--- a/src/engine/resource/RemoteResources.ts
+++ b/src/engine/resource/RemoteResources.ts
@@ -169,7 +169,6 @@ export class RemotePhysicsBody extends defineRemoteResourceClass(PhysicsBodyReso
         physics.handleToEid.delete(collider.handle);
       }
 
-      physics.handleToEid.delete(this.body.handle);
       physics.physicsWorld.removeRigidBody(this.body);
     }
 


### PR DESCRIPTION
Rigid bodies are accessed by reference `node.physicsBody.body`, while colliders are separately accessed via the `handleToEid` mapping.

Physics body adds/removes were involving rigidbody handles in the `handleToEid` mapping, which caused disposals to delete colliders belonging to other objects.